### PR TITLE
fix(api): ship precompiled email templates in Docker image

### DIFF
--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -7,6 +7,9 @@ yarn-error.log*
 # Build outputs
 dist
 build
+# Exception: precompiled email templates ship inside the source tree at
+# src/templates/email/dist/ and the runtime loads them from there.
+!src/templates/email/dist
 
 # Environment files
 .env


### PR DESCRIPTION
The .dockerignore `dist` rule was matching at any depth, silently stripping out apps/api/src/templates/email/dist/. The smoke test then failed at register time: "Email template 'auth/confirm-your-email' not found". Add an `!src/templates/email/dist` exception so the JSONs ship.

## Summary

<!-- 1–3 bullets. What changed and why. -->

## Test plan

- [ ] `pnpm check` or targeted app checks (see below)
- [ ] Stack smoke if compose/infra touched: `cd infra/compose/compose && ./dev.sh up`

### App merge bars

| Area | Command |
|------|---------|
| API | `cd apps/api && bun run validate` |
| UI | `cd apps/ui && bun run validate` |
| Docs | `cd apps/docs && bun run check` |
| Repo drift | `pnpm check` (from repo root) |

## Conventions

- [ ] No `any`, no blind `as`, no `!`
- [ ] New env vars in schema + `.env.example` (+ SECURITY.md when relevant)
- [ ] Tests updated for changed behavior

## Screenshots

<!-- Required for UI changes. -->
