### PR TITLE
docs: update boringstack docs to reflect new observability surface

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -463,6 +463,7 @@ export default defineConfig({
             { label: "Cloudflare Email", link: "/topics/cloudflare-email/" },
             { label: "Error tracking", link: "/topics/error-tracking/" },
             { label: "Observability", link: "/topics/observability/" },
+            { label: "Alerts", link: "/topics/alerts/" },
             {
               label: "Provisioning with OpenTofu",
               link: "/topics/provisioning-with-tofu/",

--- a/apps/docs/src/content/docs/reference/commands.mdx
+++ b/apps/docs/src/content/docs/reference/commands.mdx
@@ -94,6 +94,15 @@ commands run from `infra/compose/compose`; operational helper scripts live in
   <FaqItem title="Backup db (offsite)">
     `BACKUP_DRY_RUN=1 ./scripts/backup-wrapper.example.sh` then drop the flag. Data preserved.
   </FaqItem>
+  <FaqItem title="Hot-reload Prometheus rules">
+    `curl -X POST http://localhost:9090/-/reload`. Re-reads `prometheus.yml` + `rules.yml` without restarting the container.
+  </FaqItem>
+  <FaqItem title="Ping a fake alert (verify receiver wiring)">
+    ```bash
+    curl -XPOST http://localhost:9093/api/v2/alerts -H 'Content-Type: application/json' -d '[{"labels":{"alertname":"TestPing","severity":"warn","component":"manual-test"},"annotations":{"summary":"Manual ping"}}]'
+    ```
+    Auto-resolves after 5min. See [Alerts](/topics/alerts/).
+  </FaqItem>
 </FaqGroup>
 
 Minimal opt-out: `WITH_OBSERVABILITY=0 WITH_GLITCHTIP=0 ./scripts/compose-up.sh` boots just Postgres + Valkey + your apps.

--- a/apps/docs/src/content/docs/reference/env-vars.mdx
+++ b/apps/docs/src/content/docs/reference/env-vars.mdx
@@ -331,6 +331,15 @@ import FaqItem from "../../../components/FaqItem.tsx";
   <FaqItem title="GRAFANA_ADMIN_USER / GRAFANA_ADMIN_PASSWORD">
     **Repo:** infra. **Required:** rotate before exposing Grafana beyond localhost. Observability is on by default.
   </FaqItem>
+  <FaqItem title="ALERTMANAGER_SLACK_WEBHOOK_URL">
+    **Repo:** infra. **Required:** no. Slack-format webhook URL (or a Discord webhook URL with `/slack` appended). When set, Alertmanager delivers rule fires to it. Unset → alerts surface in the UI at `:9093` only. See [Alerts](/topics/alerts/).
+  </FaqItem>
+  <FaqItem title="ALERTMANAGER_SLACK_CHANNEL">
+    **Repo:** infra. **Required:** no. Default `#alerts`. Ignored by Discord (channel is fixed when the webhook is created).
+  </FaqItem>
+  <FaqItem title="ALERTMANAGER_WEBHOOK_URL">
+    **Repo:** infra. **Required:** no. Generic HTTP endpoint that receives Alertmanager's native JSON payload — for custom bridges (n8n, alerter services, PagerDuty translators). Can be set alongside the Slack URL; alerts fan out to both.
+  </FaqItem>
   <FaqItem title="*_LIMITS_CPUS / *_LIMITS_MEMORY (and reservations)">
     **Repo:** infra. **Required:** no. Per-service resource caps; see [Resource
     limits](/infra/resource-limits/).

--- a/apps/docs/src/content/docs/topics/alerts.mdx
+++ b/apps/docs/src/content/docs/topics/alerts.mdx
@@ -1,0 +1,188 @@
+---
+title: Alerts
+description: 14 default Prometheus rules + env-driven Slack, Discord, and webhook receivers in Alertmanager. Set one env var to get pager output, none to keep alerts in the UI.
+---
+
+import PageIntro from "../../../components/docs-kit/PageIntro";
+import FaqGroup from "../../../components/FaqGroup.tsx";
+import FaqItem from "../../../components/FaqItem.tsx";
+import DocCallout from "../../../components/DocCallout.tsx";
+
+<PageIntro
+  eyebrow="Alerts"
+  actions={[
+    { label: "What fires", href: "#what-rules-ship" },
+    { label: "Receivers", href: "#wiring-a-receiver" },
+  ]}
+  facts={[
+    { value: "14", label: "default rules" },
+    { value: "3", label: "receiver formats" },
+    { value: "1", label: "env var to wire" },
+  ]}
+>
+  Prometheus alert rules + Alertmanager receivers ship with the
+  observability stack. Set `ALERTMANAGER_SLACK_WEBHOOK_URL` in
+  `compose/.env` and alerts deliver to Slack, Discord, or any
+  Slack-compatible endpoint. Without it, alerts surface in the
+  Alertmanager UI at `:9093` only — useful for confirming rules fire
+  before committing to a pager destination.
+</PageIntro>
+
+## What rules ship
+
+`compose/prometheus/rules.yml` defines four rule groups covering the
+obvious failure modes. Severity labels drive Alertmanager's re-notify
+cadence: `severity=page` repeats hourly, `severity=warn` every 12
+hours.
+
+<FaqGroup>
+  <FaqItem title="boringstack-api" open>
+    `ApiServerErrorsHigh` (page, 5xx > 1% for 5min),
+    `ApiServerErrorsCritical` (page, 5xx > 5% for 2min),
+    `ApiLatencyP95High` (warn, p95 > 1s for 10min),
+    `ApiUnreachable` (page, no API traffic for 5min).
+  </FaqItem>
+  <FaqItem title="boringstack-database">
+    `PostgresDown` (page, exporter can't reach pg for 2min),
+    `PostgresConnectionsHigh` (warn, > 80% of `max_connections` for 5min),
+    `PostgresReplicationLagHigh` (warn, lag > 60s for 5min).
+  </FaqItem>
+  <FaqItem title="boringstack-host">
+    `DiskSpaceLow` (warn, < 10% free for 5min),
+    `DiskSpaceCritical` (page, < 5% free for 2min),
+    `MemoryPressureHigh` (warn, available < 10% for 10min),
+    `HostCpuSaturated` (warn, load5/cores > 1.5 for 15min),
+    `NodeExporterDown` (warn, host metrics stale for 3min).
+  </FaqItem>
+  <FaqItem title="boringstack-edge">
+    `TraefikDown` (page, Traefik metrics endpoint unreachable for 2min) —
+    Traefik is the only path into the stack in prod; this firing means
+    the site is down.
+  </FaqItem>
+</FaqGroup>
+
+Thresholds are conservative defaults for a single-host BoringStack
+deployment. Tune per workload — a busy app may legitimately push
+4xx/5xx absolute counts above what a quiet baseline catches.
+
+## Wiring a receiver
+
+Alertmanager has no native env-var substitution in its config, so the
+stack ships a small `entrypoint.sh` that renders alertmanager.yml
+from `ALERTMANAGER_*` env vars at container boot. Empty env → that
+block is omitted entirely, so `amtool check-config` stays happy.
+
+<FaqGroup>
+  <FaqItem title="Slack" open>
+    Create a Slack app + Incoming Webhook
+    ([guide](https://api.slack.com/messaging/webhooks)). Copy the URL,
+    then in `compose/.env`:
+    ```env
+    ALERTMANAGER_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T.../B.../...
+    ALERTMANAGER_SLACK_CHANNEL=#alerts
+    ```
+    Restart: `docker compose restart alertmanager`. Default message
+    template renders status, severity, component, summary, description.
+  </FaqItem>
+  <FaqItem title="Discord">
+    Discord accepts Slack-format payloads at a `/slack` suffix on its
+    webhook URL — so the **same env var** delivers there:
+    1. In Discord: `Server Settings → Integrations → Webhooks → New
+       Webhook`. Copy the URL.
+    2. **Append `/slack`**: `https://discord.com/api/webhooks/.../slack`.
+    3. Set `ALERTMANAGER_SLACK_WEBHOOK_URL` to that value in
+       `compose/.env`. `ALERTMANAGER_SLACK_CHANNEL` is ignored — the
+       channel is fixed when the webhook is created.
+    4. Restart Alertmanager.
+  </FaqItem>
+  <FaqItem title="Generic webhook (Alertmanager JSON)">
+    For custom bridges (n8n, your own alerter, PagerDuty events-v2
+    translators), use the generic receiver. It POSTs Alertmanager's
+    native JSON — different from Slack's format.
+    ```env
+    ALERTMANAGER_WEBHOOK_URL=https://your-bridge.example.com/alerts
+    ```
+    Can be set in addition to the Slack one; alerts fan out to both.
+  </FaqItem>
+  <FaqItem title="None (UI only)">
+    Leave both env vars unset. The 14 rules still fire — they land in
+    the Alertmanager UI at `http://localhost:9093`. Useful for seeing
+    what alerts look like before deciding where to pager them.
+  </FaqItem>
+</FaqGroup>
+
+## Verifying receivers work
+
+Curl a fake firing alert into Alertmanager's API directly, no waiting
+for a real incident:
+
+```bash
+curl -XPOST http://localhost:9093/api/v2/alerts \
+  -H 'Content-Type: application/json' \
+  -d '[{
+    "labels": {
+      "alertname": "TestPing",
+      "severity": "warn",
+      "component": "manual-test"
+    },
+    "annotations": {
+      "summary": "Manual ping from the alerts docs",
+      "description": "If this lands in your Slack/Discord/webhook, the receiver is wired correctly."
+    }
+  }]'
+```
+
+The alert auto-resolves after `resolve_timeout` (5 minutes) since no
+follow-up ping keeps it firing.
+
+## Adding rules
+
+Drop new entries into `compose/prometheus/rules.yml` under an
+existing group (or create a new group). Required fields per alert:
+`alert`, `expr`, `for` (optional debounce duration), `labels.severity`
+(`page` or `warn`), `annotations.summary`. The 14 bundled rules are
+worked examples.
+
+Hot-reload Prometheus without a restart:
+
+```bash
+curl -X POST http://localhost:9090/-/reload
+```
+
+## Adding routes
+
+Out of the box every alert lands in the single `default` receiver. To
+route specific labels to different receivers (e.g. `component=database`
+to a DBA channel), edit `compose/alertmanager/entrypoint.sh` directly —
+it's a small shell script with `cat >> "$CFG" <<EOF` blocks for each
+receiver. Append your own routes block + matching receivers.
+
+If the routing grows beyond a handful of cases, graduate to a static
+`alertmanager.yml` you maintain yourself and remove the entrypoint
+script.
+
+<DocCallout
+  variant="tip"
+  title="Pager fatigue is a real cost"
+  eyebrow="Tuning thresholds"
+>
+  The default `for:` durations are deliberately generous to avoid
+  3am pages on transient blips. If you find you're regularly silencing
+  the same alert, the threshold is wrong — either raise the duration,
+  the rate threshold, or both. An alert that fires and nobody acts on
+  is worse than no alert.
+</DocCallout>
+
+## Source
+
+- [`compose/prometheus/rules.yml`](https://github.com/boringstack-xyz/boringstack/blob/main/infra/compose/compose/prometheus/rules.yml) — the 14 rules.
+- [`compose/alertmanager/entrypoint.sh`](https://github.com/boringstack-xyz/boringstack/blob/main/infra/compose/compose/alertmanager/entrypoint.sh) — env-driven config renderer.
+- [`infra/compose/docs/alerts.md`](https://github.com/boringstack-xyz/boringstack/blob/main/infra/compose/docs/alerts.md) — the operator-side runbook.
+
+## Related
+
+- [Observability](/topics/observability/) — the metrics + logs stack
+  these alerts run inside of.
+- [Error tracking](/topics/error-tracking/) — Sentry/GlitchTip catches
+  exceptions; Alertmanager catches "metrics-shaped" failures (rates,
+  resource pressure, unreachability). Different surfaces, same goal.

--- a/apps/docs/src/content/docs/topics/error-tracking.mdx
+++ b/apps/docs/src/content/docs/topics/error-tracking.mdx
@@ -39,12 +39,14 @@ The SDKs don't know which one they're talking to. Choosing is a one-env-var chan
   <FaqItem title="Sentry SDK on both sides (not a custom shim)" open>
     Same SDK interface and error format across both services.
   </FaqItem>
-  <FaqItem title="GlitchTip as the self-host option">
-    Wire-compatible with Sentry; runs on the same Postgres + Valkey the app
-    already uses.
+  <FaqItem title="GlitchTip as the self-host option, on by default">
+    Wire-compatible with Sentry; runs on the same Postgres + Valkey the
+    app already uses. `WITH_GLITCHTIP=0` opts out.
   </FaqItem>
   <FaqItem title="Empty DSN: SDK is a no-op">
-    Dev stays clean; tests do not ship error reports.
+    Tests do not ship error reports. Once you copy a project DSN from
+    the GlitchTip UI into `SENTRY_DSN` / `VITE_SENTRY_DSN`, error
+    capture starts.
   </FaqItem>
   <FaqItem title="Replay-on-error on, full-session replays off">
     Captures the broken flow without storing healthy sessions.
@@ -52,7 +54,61 @@ The SDKs don't know which one they're talking to. Choosing is a one-env-var chan
   <FaqItem title="Single env var per side: SENTRY_DSN (API), VITE_SENTRY_DSN (UI)">
     Same protocol regardless of backend; swap is one redeploy.
   </FaqItem>
+  <FaqItem title="Events carry user.id + trace_id automatically">
+    The API's auth plugin calls `Sentry.setUser({id, email})` once it
+    resolves a session; the UI's `SentryUserSync` does the same after
+    every `useMe` change. Errors land in GlitchTip tagged with the
+    user that hit them. See "Correlation" below for the full pivot
+    surface.
+  </FaqItem>
 </FaqGroup>
+
+## Correlation: GlitchTip ↔ Loki ↔ requestId
+
+Errors are useful in proportion to how easily you can reach the
+context around them. The stack wires a single chain of IDs across
+browser, API, log store, and error tracker so any one of them
+takes you to the other three.
+
+```mermaid
+flowchart LR
+  user["Browser action"] -->|sentry-trace header| api["API request handler"]
+  api -->|Pino mixin| logs["Loki log lines<br/>(trace_id, requestId, userId)"]
+  api -->|on error| gt["GlitchTip event<br/>(tagged: trace_id, user.id)"]
+  logs -.->|click trace_id link| gt
+  gt -.->|click trace_id tag| logs
+```
+
+**What flows automatically:**
+
+- `trace_id` + `span_id`: the UI's Sentry SDK adds `sentry-trace` /
+  `traceparent` headers to every `/api/*` fetch via
+  `browserTracingIntegration`; the API's Sentry init reads them; the
+  Pino logger's mixin injects them on every log record; Promtail
+  promotes them to Loki structured metadata.
+- `userId`: the API's auth plugin calls `Sentry.setUser({id, email})`
+  on every authenticated request. The Pino mixin reads `userId` from
+  the Sentry scope and emits it on each log line. The UI's
+  `SentryUserSync` provider mirrors the same call after login, MFA
+  verify, account switch, page reload — anywhere `useMe` resolves.
+- `requestId`: a UUID assigned by the API's request-logger middleware,
+  returned as the `x-request-id` header and present on every log line
+  for that request.
+
+**Where the click-through lives:**
+
+- **Grafana → GlitchTip** — the "BoringStack — API logs" dashboard
+  defines clickable data links on `trace_id` and `userId` in the live
+  log panel. Expand any log line, click the field → opens GlitchTip
+  filtered to that trace / user in a new tab. The dashboard variables
+  `$glitchtip_url` and `$glitchtip_org` configure the target (defaults
+  fit the bundled GlitchTip; edit once per environment).
+- **Grafana → Grafana** — `requestId` link opens Explore with a Loki
+  query pre-filtered to that one request's lines.
+- **GlitchTip → Grafana** — configure once in GlitchTip's project
+  settings (UI, not code): a `tags.trace_id` external link template
+  pointing at Grafana Explore with `{compose_service="api-dev"} | json | trace_id="<value>"`.
+  Each event detail then shows a "View logs" link.
 
 ## How it's wired
 

--- a/apps/docs/src/content/docs/topics/observability.mdx
+++ b/apps/docs/src/content/docs/topics/observability.mdx
@@ -57,18 +57,28 @@ flowchart LR
 <FaqGroup>
   <FaqItem title="Grafana" open>
     Host `:3010`. Default admin / change-me (override via env). Datasources
-    for Prometheus and Loki auto-provisioned.
+    for Prometheus and Loki auto-provisioned. Five baseline dashboards
+    auto-load — see the "Default dashboards" section below.
   </FaqItem>
   <FaqItem title="Prometheus">
     Internal. Scrapes itself, Alertmanager, Traefik (prod profile),
-    postgres-exporter, node-exporter. Configurable retention.
+    postgres-exporter, node-exporter, and `apps/api` `/metrics`. 14
+    bundled alert rules (API errors/latency, Postgres health, host
+    disk/memory/CPU, edge); see [Alerts](/topics/alerts/) for tuning.
   </FaqItem>
   <FaqItem title="Loki">
-    Internal. Per-container labels; configurable retention.
+    Internal. Per-container labels; configurable retention. The api
+    containers' Pino JSON is parsed into structured fields by Promtail's
+    Pino pipeline, so log filtering by `level` and pivoting by `trace_id`
+    / `requestId` / `userId` are first-class.
   </FaqItem>
   <FaqItem title="Promtail">
-    Sidecar. Tails `/var/lib/docker/containers/*.log` so every container's
-    stdout is queryable as labeled logs.
+    Sidecar. Two pipelines: a plain pipeline labels everything by
+    `compose_service`; a Pino-aware pipeline on the api containers
+    parses JSON, promotes `level` (lowercased) as a Loki label, and
+    surfaces `requestId` / `trace_id` / `span_id` / `userId` as
+    structured metadata — so Grafana auto-colours by level and the
+    correlation IDs are clickable.
   </FaqItem>
   <FaqItem title="node-exporter">
     Host metrics: CPU, memory, disk, network.
@@ -77,9 +87,12 @@ flowchart LR
     Postgres metrics: connections, transactions, table sizes.
   </FaqItem>
   <FaqItem title="Alertmanager">
-    Internal. Receivers are not wired by default, paging strategy is
-    project-specific, so the template ships the plumbing and you add the
-    routes.
+    Wired with env-driven Slack/Discord/webhook receivers. Set
+    `ALERTMANAGER_SLACK_WEBHOOK_URL` (Slack-format — works for Discord
+    too with the `/slack` suffix) and/or `ALERTMANAGER_WEBHOOK_URL`
+    (Alertmanager JSON) in `compose/.env`. Without either set, alerts
+    still fire into the Alertmanager UI at `:9093` only. Walkthrough:
+    [Alerts](/topics/alerts/).
   </FaqItem>
 </FaqGroup>
 
@@ -104,22 +117,50 @@ Prometheus scrapes the api on the `boringstack-api` job (dev profile
 hits `api-dev:7330`, prod profile hits `api:7330`); each target is
 labelled with its `profile`.
 
-## Default dashboard
+## Default dashboards
 
-`compose/grafana/dashboards/boringstack-api.json` ships with the
-overlay and auto-loads via the provisioning provider. Panels:
+Five dashboards auto-load from `compose/grafana/dashboards/` via the
+provisioning provider. Open them at `http://localhost:3010` (admin /
+change-me by default) under the BoringStack folder.
 
-- Request rate per route
-- Request latency p95 per route
-- 5xx error rate (stat)
-- Memory (RSS + heap used)
-- Event-loop lag (p50, p99)
-- Process CPU
-- Requests by status (stacked)
+<FaqGroup>
+  <FaqItem title="BoringStack — API" open>
+    RED panels per route: request rate, p95 latency, 5xx rate, requests
+    by status. Plus Node.js runtime: heap, RSS, event-loop lag p50/p99,
+    process CPU. First place to look for "is the API hot?"
+  </FaqItem>
+  <FaqItem title="BoringStack — API logs">
+    Error / warn / info / total counts (stats), log volume per minute
+    stacked by level (colour-coded), top error/warn events aggregated
+    by Pino `event` field, top routes producing errors, plus two live
+    log streams — application events (Drizzle SQL filtered out) and
+    raw database queries (Drizzle stdout). Structured-metadata fields
+    on each line are clickable: trace_id and userId open GlitchTip
+    search, requestId opens a Loki Explore pre-filtered to that
+    request's lines.
+  </FaqItem>
+  <FaqItem title="BoringStack — UI logs">
+    Vite + nginx output. Substring-matched error count (heuristic since
+    Vite isn't structured), HMR / reload activity, per-container log
+    volume, per-minute error timeseries, plus a live filterable stream.
+  </FaqItem>
+  <FaqItem title="BoringStack — Postgres">
+    Connections vs `max_connections`, cache hit ratio (target >95%),
+    transactions per second (commits + rollbacks), database size,
+    longest-running transaction, deadlocks per minute. "Is the DB hot?"
+  </FaqItem>
+  <FaqItem title="BoringStack — Host">
+    CPU by mode (user / system / iowait / ...), iowait stat (red when
+    sustained — usually means disk-bound), memory used / cached /
+    available, filesystem % per mount (red at >85%), network rx/tx.
+    "Is the box itself the problem?"
+  </FaqItem>
+</FaqGroup>
 
-Drop additional dashboards into the same directory and Grafana picks
-them up within 30 s. Good community starting points: Node Exporter
-Full (id `1860`), PostgreSQL exporter quickstart (id `9628`).
+Drop additional dashboards into `compose/grafana/dashboards/` and
+Grafana picks them up within 30 seconds. Heavier community starters
+to pair with the defaults: Node Exporter Full (id `1860`), PostgreSQL
+exporter quickstart (id `9628`), Loki Logs (id `13186`).
 
 ## Design choices
 
@@ -127,21 +168,35 @@ Full (id `1860`), PostgreSQL exporter quickstart (id `9628`).
   <FaqItem title="Self-hosted, not SaaS" open>
     Zero per-event cost; data stays on your infra.
   </FaqItem>
-  <FaqItem title="Prometheus + Loki, not OpenTelemetry collector">
-    Two well-known projects beat one unfamiliar abstraction. The stack
-    can grow into OTel later without re-platforming.
+  <FaqItem title="On by default in dev and prod">
+    The whole point of running the stack in dev is so you've already
+    used Grafana before prod day-one. Disabling it (`WITH_OBSERVABILITY=0`)
+    is supported but reintroduces the "first time I open this dashboard
+    is during an incident" anti-pattern.
   </FaqItem>
-  <FaqItem title="Promtail labels logs per container">
-    "Show me api-prod errors in the last hour" is one filter, not a
-    regex against a giant text blob.
+  <FaqItem title="Promtail labels logs per container, parses Pino on the API">
+    "Show me api-prod errors in the last hour" is one label filter, not
+    a regex against a giant text blob. Grafana auto-colours each line
+    by `level` because Promtail's Pino pipeline emits it as a label.
   </FaqItem>
-  <FaqItem title="Grafana auto-provisions datasources">
+  <FaqItem title="trace_id flows browser → API → Loki">
+    The Sentry SDK (browser + API) propagates `sentry-trace` /
+    `traceparent` headers on every `/api/*` request. The API logger's
+    Pino mixin injects the active span's `trace_id` + `span_id` on
+    every log record. Result: one trace ID stitches together the
+    browser action, the API request handler, the DB queries it
+    triggered, and the GlitchTip event if anything failed.
+  </FaqItem>
+  <FaqItem title="Grafana auto-provisions datasources + dashboards">
     Stack boots usable; no manual wiring after `up -d`. Adding a
     dashboard is a file drop, not a UI click-through.
   </FaqItem>
-  <FaqItem title="Alertmanager included but not wired by default">
-    Pager strategy is project-specific; the plumbing is there when you
-    need it.
+  <FaqItem title="Alertmanager is env-driven, not stub-empty">
+    Set one env var (`ALERTMANAGER_SLACK_WEBHOOK_URL`) and alerts
+    deliver. Discord works through the same env via Slack-format
+    compatibility. No receiver set → alerts surface in the
+    Alertmanager UI only. Full walkthrough in
+    [Alerts](/topics/alerts/).
   </FaqItem>
 </FaqGroup>
 
@@ -162,25 +217,31 @@ pg_stat_database_numbackends{datname="app"}
 rate(http_requests_total[5m]) by (route)
 ```
 
-**Logs (Loki, LogQL).** These work today, every container streams to
-Loki:
+**Logs (Loki, LogQL).** The api containers' Pino JSON is parsed by
+Promtail, so common queries don't need `| json` re-parsing:
 
 ```bash
-# All API errors in the last hour
-{container=~"ai-starter-.*-api-dev-1"} |= "level=ERROR"
+# All API errors in the last hour (level is a Loki label)
+{compose_service=~"api-dev|api", level="error"}
 
-# Worker jobs by status
-{container=~"ai-starter-.*-api-.*"} | json | event="email_delivery_completed"
+# Worker jobs by status — fall back to | json for non-label fields
+{compose_service=~"api-dev|api"} | json | event="email_delivery_completed"
+
+# Every log line for a specific trace (correlation across requests)
+{compose_service=~"api-dev|api"} | json | trace_id="abc123..."
+
+# All activity by a specific user
+{compose_service=~"api-dev|api"} | json | userId="user-uuid..."
 ```
 
 ## Adding an alert
 
-1. Drop a rule file in `compose/prometheus/rules/` (e.g. `api-error-rate.yml`).
-2. Configure routing in `compose/alertmanager/alertmanager.yml`.
-3. `docker compose restart prometheus alertmanager`.
-
-Alertmanager can route to Slack, email, PagerDuty, or a webhook. The
-template ships the structure; you fill in your receiver.
+1. Edit `compose/prometheus/rules.yml` (single bundled file; 14 rules
+   ship by default). Add a new entry under one of the existing
+   `groups:` or create a new group.
+2. Hot-reload Prometheus: `curl -X POST http://localhost:9090/-/reload`
+   (or full restart: `docker compose restart prometheus`).
+3. Set a receiver if you haven't: see [Alerts](/topics/alerts/).
 
 ## Cost
 


### PR DESCRIPTION
Catches the operator-facing docs site up with all the infra and
correlation work that landed across PRs #45, #46, #47, and #48 —
defaults flip + dashboards + structured logging + user/trace
correlation + env-driven alert receivers.

topics/observability.mdx
- "What ships" — five dashboards (was one); Pino pipeline detail;
  Alertmanager wired with env-driven receivers (was "you wire it
  yourself").
- "Default dashboards" — full per-dashboard breakdown (API, API
  logs, UI logs, Postgres, Host) with what each is best at and a
  pointer to the click-through data links on trace_id / userId /
  requestId.
- "Design choices" — added "on by default", trace_id flow, and
  env-driven Alertmanager entries; dropped the now-misleading
  "Prometheus + Loki, not OpenTelemetry" claim (the Sentry tracing
  side does carry traces).
- "Querying" — LogQL examples now use the `level` label (was the
  broken `level=ERROR` substring match) and include trace_id /
  userId pivot queries.
- "Adding an alert" — points at the single bundled rules.yml and
  the new Alerts topic.

topics/error-tracking.mdx
- New "Correlation: GlitchTip ↔ Loki ↔ requestId" section with a
  mermaid diagram of the trace_id flow (browser → API → Loki +
  GlitchTip), a description of what flows automatically (trace_id /
  span_id / userId / requestId), and the three click-through paths
  (Grafana → GlitchTip via dashboard data links, Grafana → Grafana
  via the requestId link, GlitchTip → Grafana via the operator-side
  one-time tag link template).
- Design-choices block updated with on-by-default GlitchTip and
  the user.id / trace_id tagging.

topics/alerts.mdx (new)
- New topic page promoting the alerts walkthrough to the user-facing
  docs site. Covers what the 14 default rules fire on, the three
  receiver formats (Slack, Discord-via-/slack-suffix, generic
  webhook), an end-to-end curl one-liner to ping a fake alert, how
  to add rules, and the cost-of-pager-fatigue note.

reference/env-vars.mdx
- New entries for ALERTMANAGER_SLACK_WEBHOOK_URL,
  ALERTMANAGER_SLACK_CHANNEL, ALERTMANAGER_WEBHOOK_URL.

reference/commands.mdx
- "Hot-reload Prometheus rules" — `curl POST /-/reload`.
- "Ping a fake alert (verify receiver wiring)" — the verification
  one-liner from the new Alerts topic.

astro.config.mjs
- Wire the new Alerts topic into the Topics sidebar between
  Observability and Provisioning with OpenTofu.

Verification: `bun run build` clean, 66 pages built (was 65, now +1
for Alerts), pagefind index built without errors.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
