### PR TITLE
fix(observability): Promtail template uses ToLower (capital T)

### DIFF
--- a/infra/compose/compose/promtail/promtail-config.yml
+++ b/infra/compose/compose/promtail/promtail-config.yml
@@ -83,9 +83,13 @@ scrape_configs:
             msg: msg
       # Lowercase Pino's level ("INFO" → "info"). Promote as the `level`
       # label so Grafana's logs panel auto-colours each line by severity.
+      # Note: Promtail's template stage exposes Go's strings.ToLower as
+      # `ToLower` (capital T) — `toLower` from Sprig is NOT registered
+      # here. Using the lowercase form crashes the container with
+      # `function "toLower" not defined` at config load.
       - template:
           source: level
-          template: '{{ .level | toLower }}'
+          template: '{{ ToLower .level }}'
       - labels:
           level:
       # High-cardinality correlation IDs go into structured metadata


### PR DESCRIPTION
Hot-fix for a real regression introduced in commit 716de4e (PR #47,
the log/trace correlation work): the Pino-level template was written
as `{{ .level | toLower }}` (Sprig-style lowercase), but Promtail's
template stage doesn't register Sprig — it only exposes Go's
strings.ToLower as a function named `ToLower` (capital T).

The result was the Promtail container failed to start with:

  failed to make Docker service discovery target manager:
  invalid template stage config:
  template: pipeline_template:1: function "toLower" not defined

…and has been crashlooping in dev / restart-looping in any other
deployment since PR #47 landed. Net effect: Loki has been receiving
zero log lines for that window — the structured-logging pipeline
silently went dark.

Fix: capitalised function name + a comment so the same mistake
doesn't happen again on future template changes.

Verification: `grafana/promtail:3.2.1 -check-syntax` clean, and the
container now starts (logs `Starting Promtail` without the
function-not-defined error) against this config.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
