### PR TITLE
chore(observability): pin Tempo image + fix size-diff workflow auth

### DIFF
--- a/.github/workflows/apps-ui-bundle-diff.yml
+++ b/.github/workflows/apps-ui-bundle-diff.yml
@@ -65,6 +65,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          # v1.8.0 doesn't reliably fall back to env GITHUB_TOKEN — it
+          # initialises Octokit before reading the env, so the token must
+          # be passed explicitly as a `with:` input. Without this, every
+          # PR run fails with "Parameter token or opts.auth is required"
+          # even though the env was set. Keeping the env: line above as
+          # belt-and-braces for any future action version that flips back.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           package_manager: npm
           script: build
           skip_step: install

--- a/infra/compose/compose/docker-compose.observability.yml
+++ b/infra/compose/compose/docker-compose.observability.yml
@@ -125,7 +125,7 @@ services:
 
   tempo:
     profiles: ["observability"]
-    image: grafana/tempo:2.6.1
+    image: grafana/tempo:2.6.1@sha256:ef4384fce6e8ad22b95b243d8fc165628cda655376fd50e7850536ad89d71d50
     restart: unless-stopped
     command: ["-config.file=/etc/tempo/tempo.yml"]
     volumes:


### PR DESCRIPTION
Two small follow-ups to the recent observability work — both pure
hygiene, no behavioural changes.

Tempo image pinned by digest
----------------------------
PR #50 introduced `grafana/tempo:2.6.1` as a tag-only reference
because OrbStack wasn't running when the commit was prepared. Every
other image in the observability stack (prometheus, grafana, loki,
promtail, alertmanager, postgres-exporter, node-exporter) is pinned
to a specific `@sha256:` digest for supply-chain hygiene. Tempo now
matches:

  grafana/tempo:2.6.1@sha256:ef4384fce6e8ad22b95b243d8fc165628cda655376fd50e7850536ad89d71d50

size-diff workflow github_token
-------------------------------
The `bundle-diff` workflow on every PR has been printing a red ✗
with `Parameter token or opts.auth is required` since #46 introduced
the dashboard work. The action (`andresz1/size-limit-action@v1.8.0`)
initialises Octokit *before* reading the env var GITHUB_TOKEN, so
the env-based pass we had wasn't reaching it. Fix: pass the token
explicitly as a `with:` input too. The env line stays as
belt-and-braces in case a future action version flips back to env.

Result: no more spurious red ✗ on PRs that touch apps/ui.

Verification: docker compose config dry-run exits 0 with the pinned
Tempo image; workflow YAML still parses; pre-push gate green.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
