### PR TITLE
feat(observability): auto-wire SENTRY_DSN + VITE_SENTRY_DSN from GlitchTip

### DIFF
--- a/apps/docs/src/content/docs/topics/error-tracking.mdx
+++ b/apps/docs/src/content/docs/topics/error-tracking.mdx
@@ -44,9 +44,11 @@ The SDKs don't know which one they're talking to. Choosing is a one-env-var chan
     app already uses. `WITH_GLITCHTIP=0` opts out.
   </FaqItem>
   <FaqItem title="Empty DSN: SDK is a no-op">
-    Tests do not ship error reports. Once you copy a project DSN from
-    the GlitchTip UI into `SENTRY_DSN` / `VITE_SENTRY_DSN`, error
-    capture starts.
+    Tests do not ship error reports. The dev stack auto-wires
+    `SENTRY_DSN` and `VITE_SENTRY_DSN` from the bundled GlitchTip
+    (`scripts/glitchtip-fetch-dsn.sh`, called by `dev.sh up -d`), so
+    first boot lands ready-to-ship; pre-set values are left alone so
+    you can point at hosted Sentry instead.
   </FaqItem>
   <FaqItem title="Replay-on-error on, full-session replays off">
     Captures the broken flow without storing healthy sessions.
@@ -143,7 +145,7 @@ GlitchTip is Apache-licensed and Sentry-API-compatible. It runs as part of the d
 WITH_GLITCHTIP=0 ./dev.sh up -d  # opt out if you'd rather not run it
 ```
 
-First boot bootstraps a superuser (`admin@localhost` / `admin123456`), a default org, and two projects (`API` and `Frontend`). Visit `http://glitchtip.localhost`, grab each project's DSN, and drop them into the matching env vars.
+First boot bootstraps a superuser (`admin@localhost` / `admin123456`), a default org, and two projects (`API` and `Frontend`). `dev.sh up -d` then runs `scripts/glitchtip-fetch-dsn.sh` in the background — it pulls the DSNs out of GlitchTip's Django ORM, writes them into `compose/.env` as `SENTRY_DSN` / `VITE_SENTRY_DSN`, and restarts `api-dev` + `ui-dev`. Visit `http://glitchtip.localhost` to browse events; the DSN paste step is gone.
 
 The overlay reuses the base stack's Postgres (in a separate `glitchtip` database) and Valkey (DB 1). Adding GlitchTip costs two extra containers, not a separate database server.
 

--- a/infra/compose/compose/.env.example
+++ b/infra/compose/compose/.env.example
@@ -128,6 +128,16 @@ GRAFANA_ADMIN_PASSWORD=change-me
 # GLITCHTIP_SUPERUSER_PASSWORD=admin123456
 # GLITCHTIP_DEFAULT_ORG_NAME=Local
 # GLITCHTIP_DEFAULT_PROJECTS=API,Frontend
+#
+# DSNs — auto-wired by `scripts/glitchtip-fetch-dsn.sh`, which `dev.sh up -d`
+# runs in the background on the dev stack. The script reads the DSNs from
+# GlitchTip's Django ORM and writes them here, then restarts api-dev / ui-dev
+# so they pick up the values. DSNs are public keys (they ship in the browser
+# bundle), not secrets — safe to keep in this file even if it's committed.
+# Set them by hand if you'd rather skip the auto-wire (or are pointing at
+# hosted Sentry / a different GlitchTip):
+# SENTRY_DSN=                         # consumed by api-dev (and api in prod)
+# VITE_SENTRY_DSN=                    # consumed by ui-dev (and ui in prod build)
 
 # --- Mailpit (optional, dev-only, WITH_MAILPIT=1) -----------------------
 # Local SMTP catcher. Captures emails sent by the api when EMAIL_PROVIDER=smtp

--- a/infra/compose/compose/dev.sh
+++ b/infra/compose/compose/dev.sh
@@ -117,4 +117,25 @@ if [[ $# -eq 0 ]]; then
   set -- up -d
 fi
 
-exec docker compose "${COMPOSE_FILES[@]}" "${PROFILE_ARGS[@]}" "$@"
+# Auto-wire GlitchTip → API/UI DSNs after a detached `up` on the dev stack.
+# Skipped for prod (operator owns those DSNs), smoke (no GlitchTip), and
+# non-up actions (down/logs/ps/etc.) which run a pass-through compose call.
+WIRE_GLITCHTIP=0
+if [[ "$STACK" == "dev" && "$WITH_GLITCHTIP" == "1" && "${1:-}" == "up" ]]; then
+  for arg in "$@"; do
+    if [[ "$arg" == "-d" || "$arg" == "--detach" ]]; then
+      WIRE_GLITCHTIP=1
+      break
+    fi
+  done
+fi
+
+if [[ "$WIRE_GLITCHTIP" == "1" ]]; then
+  docker compose "${COMPOSE_FILES[@]}" "${PROFILE_ARGS[@]}" "$@"
+  # Background — GlitchTip's first-boot bootstrap can take a minute and
+  # we don't want to hold the dev loop. The fetch script is idempotent
+  # and silent when wiring is already done.
+  ( "$ROOT/../scripts/glitchtip-fetch-dsn.sh" --quiet & ) >/dev/null 2>&1
+else
+  exec docker compose "${COMPOSE_FILES[@]}" "${PROFILE_ARGS[@]}" "$@"
+fi

--- a/infra/compose/compose/docker-compose.yml
+++ b/infra/compose/compose/docker-compose.yml
@@ -242,6 +242,10 @@ services:
       # `tempo` service over the shared `backend` network.
       OTEL_EXPORTER_OTLP_ENDPOINT: ${API_DEV_OTEL_EXPORTER_OTLP_ENDPOINT:-http://tempo:4318}
       OTEL_SERVICE_NAME: ${API_DEV_OTEL_SERVICE_NAME:-boringstack-api-dev}
+      # Auto-wired by scripts/glitchtip-fetch-dsn.sh after first up; empty
+      # until that script writes a value into compose/.env. Sentry init
+      # is a no-op when empty, so an unwired stack still boots cleanly.
+      SENTRY_DSN: ${SENTRY_DSN:-}
     depends_on:
       postgres:
         condition: service_healthy
@@ -293,6 +297,10 @@ services:
       CI: "true"
       VITE_API_URL: ""
       VITE_API_PROXY_TARGET: http://api-dev:7330
+      # Auto-wired by scripts/glitchtip-fetch-dsn.sh after first up; empty
+      # until that script writes a value into compose/.env. Vite picks
+      # this up at dev-server startup and exposes it as import.meta.env.
+      VITE_SENTRY_DSN: ${VITE_SENTRY_DSN:-}
     depends_on:
       api-dev:
         condition: service_healthy

--- a/infra/compose/docs/glitchtip.md
+++ b/infra/compose/docs/glitchtip.md
@@ -17,7 +17,11 @@ That's it. `dev.sh` auto-seeds a dev-only `GLITCHTIP_SECRET_KEY` if you don't se
 - creates the superuser `admin@localhost` / `admin123456` (override via `GLITCHTIP_SUPERUSER_*` in `.env`)
 - creates a default organization (`Local`) with two projects (`API`, `Frontend`)
 
-Visit **http://glitchtip.localhost** and log in. Each project has a DSN under `Settings → Client Keys`. Copy them into the the API app's `.env` (as `SENTRY_DSN`) and the the UI app's `.env.local` (as `VITE_SENTRY_DSN`).
+**DSNs are auto-wired.** `dev.sh up -d` runs `scripts/glitchtip-fetch-dsn.sh` in the background once GlitchTip is up. The script reads the DSNs for the `API` and `Frontend` projects from GlitchTip's Django ORM, writes them to `compose/.env` as `SENTRY_DSN` and `VITE_SENTRY_DSN`, and restarts `api-dev` + `ui-dev` so they pick the values up. Re-runs are idempotent — the script exits silently when the wiring already matches.
+
+Visit **http://glitchtip.localhost** to log in if you want to browse events, configure alerts, or rotate the superuser password. The DSN copy-paste step from older docs is gone.
+
+If you'd rather point at hosted Sentry or a different GlitchTip, set `SENTRY_DSN` / `VITE_SENTRY_DSN` manually in `compose/.env` before `up`. The script only writes when the .env value is empty — any non-empty value is treated as deliberate and left alone. To rewire after wiping the GlitchTip Postgres volume, clear those two lines and re-run `./scripts/glitchtip-fetch-dsn.sh`.
 
 ## How it's wired
 
@@ -57,18 +61,11 @@ The `/api/*` router has **no Basic Auth** so client SDKs can POST events without
 
 ## SDK integration
 
-**API (apps/api)** — `bun add @sentry/bun` (or use the the API app's existing Sentry middleware):
-```ts
-import * as Sentry from "@sentry/bun";
+The SDKs are already wired in both apps; the auto-wire above gives them DSNs to talk to.
 
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,           // from GlitchTip → Project → Client Keys
-  tracesSampleRate: 1.0,
-  environment: process.env.NODE_ENV,
-});
-```
+**API (apps/api)** — `@sentry/bun` is initialised in `apps/api/src/config/sentry/sentry.ts`. Reads `SENTRY_DSN` from env; no-op when empty. `tracesSampleRate` defaults to `0` (env-tunable via `SENTRY_TRACES_SAMPLE_RATE`) — OTel ships traces to Tempo, Sentry stays error-capture-only.
 
-**UI (apps/ui)** — uses `@sentry/react` and reads `VITE_SENTRY_DSN` from `src/lib/env`. Just set the DSN; the existing wiring sends events to whichever endpoint that DSN points at.
+**UI (apps/ui)** — `@sentry/react` is initialised in `apps/ui/src/app/main.tsx`. Reads `VITE_SENTRY_DSN` at dev-server start (or build time for the prod bundle); no-op when empty. Same posture: `tracesSampleRate: 0`, error capture only, trace IDs propagate via `browserTracingIntegration` so server-side spans land in Tempo with the same ID.
 
 ## Verifying ingestion
 

--- a/infra/compose/scripts/glitchtip-fetch-dsn.sh
+++ b/infra/compose/scripts/glitchtip-fetch-dsn.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Auto-wire SENTRY_DSN + VITE_SENTRY_DSN from GlitchTip into compose/.env.
+#
+# What it does:
+#   1. Waits for the `glitchtip-web` container to be healthy.
+#   2. Pulls the DSN for the auto-created `API` and `Frontend` projects
+#      via `manage.py shell` (no API auth dance — talks to Django direct).
+#   3. Writes / updates SENTRY_DSN and VITE_SENTRY_DSN in compose/.env.
+#   4. Restarts api-dev + ui-dev so they pick up the new env on next request.
+#
+# Idempotent: skips writing if the .env values already match the live DSNs.
+# Safe to invoke from dev.sh on every `up` — does nothing on subsequent
+# runs once .env is wired.
+#
+# Usage:
+#   ./scripts/glitchtip-fetch-dsn.sh         # foreground, verbose
+#   ./scripts/glitchtip-fetch-dsn.sh --quiet # background-friendly, less output
+#
+# DSNs are public keys (they ship in the browser bundle), not secrets — safe
+# to write to compose/.env even if that file is committed.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_DIR="$ROOT/compose"
+ENV_FILE="$COMPOSE_DIR/.env"
+
+QUIET=0
+if [[ "${1:-}" == "--quiet" ]]; then
+  QUIET=1
+fi
+
+log() {
+  if [[ "$QUIET" == "0" ]]; then
+    echo "[glitchtip-dsn] $*"
+  fi
+}
+
+warn() {
+  echo "[glitchtip-dsn] $*" >&2
+}
+
+cd "$COMPOSE_DIR"
+
+# Project name is fixed via docker-compose.yml's top-level `name:` directive.
+# Don't hard-code that string — `docker compose config` is the source of
+# truth (also handles COMPOSE_PROJECT_NAME overrides). Falls back to the
+# directory name if config is unparseable for some reason.
+PROJECT_NAME="$(docker compose config --format json 2>/dev/null \
+  | grep -o '"name":[[:space:]]*"[^"]*"' | head -n1 \
+  | sed 's/.*"name":[[:space:]]*"\([^"]*\)".*/\1/' \
+  || true)"
+PROJECT_NAME="${PROJECT_NAME:-$(basename "$COMPOSE_DIR")}"
+
+# Resolve glitchtip-web by Docker compose labels rather than `docker compose
+# ps -q`, because `ps` validates the service against the *loaded* compose
+# files and the base docker-compose.yml doesn't define glitchtip-web — the
+# overlay does. Label lookup is project-scoped and overlay-agnostic.
+WEB_CONTAINER="$(docker ps -q \
+  --filter "label=com.docker.compose.project=${PROJECT_NAME}" \
+  --filter "label=com.docker.compose.service=glitchtip-web" \
+  | head -n1)"
+
+if [[ -z "$WEB_CONTAINER" ]]; then
+  log "glitchtip-web is not running — skipping auto-wire."
+  exit 0
+fi
+
+# GlitchTip Celery/Django boot takes ~30–60s on a cold start. Poll the
+# container's `manage.py check --database default` until it succeeds — that
+# proves migrations have applied and the ORM is reachable.
+log "Waiting for glitchtip-web to be ready..."
+DEADLINE=$(( $(date +%s) + 180 ))
+while (( $(date +%s) < DEADLINE )); do
+  if docker exec "$WEB_CONTAINER" ./manage.py check --database default >/dev/null 2>&1; then
+    break
+  fi
+  sleep 3
+done
+
+if ! docker exec "$WEB_CONTAINER" ./manage.py check --database default >/dev/null 2>&1; then
+  warn "glitchtip-web didn't become ready within 180s — skipping auto-wire."
+  warn "Re-run later with: ./scripts/glitchtip-fetch-dsn.sh"
+  exit 0
+fi
+
+# Fetch DSNs via the Django ORM. Two import paths are tried because GlitchTip
+# moved its `projects` app between releases. The shell script prints
+# `<ProjectName>=<dsn>` lines or `__missing__=<ProjectName>` if a project
+# doesn't exist yet (it usually does — GLITCHTIP_DEFAULT_PROJECTS creates
+# `API` and `Frontend` on first boot of an empty DB).
+log "Fetching project DSNs from GlitchTip..."
+PYTHON_PROBE=$(cat <<'PYEOF'
+import sys
+try:
+    from apps.projects.models import Project
+except Exception:
+    try:
+        from glitchtip.projects.models import Project
+    except Exception:
+        try:
+            from projects.models import Project
+        except Exception as e:
+            sys.stderr.write(f"could not import Project model: {e}\n")
+            sys.exit(2)
+
+wanted = ["API", "Frontend"]
+for name in wanted:
+    p = Project.objects.filter(name=name).first()
+    if not p:
+        print(f"__missing__={name}")
+        continue
+    key = p.projectkey_set.first()
+    if not key:
+        print(f"__nokey__={name}")
+        continue
+    print(f"{name}={key.get_dsn()}")
+PYEOF
+)
+
+OUTPUT="$(docker exec "$WEB_CONTAINER" ./manage.py shell -c "$PYTHON_PROBE" 2>/dev/null || true)"
+
+if [[ -z "$OUTPUT" ]]; then
+  warn "manage.py shell returned no output — model import probably failed."
+  warn "Open an issue or run manually:"
+  warn "  docker compose exec glitchtip-web ./manage.py shell"
+  exit 0
+fi
+
+API_DSN=""
+UI_DSN=""
+while IFS= read -r line; do
+  case "$line" in
+    API=*) API_DSN="${line#API=}" ;;
+    Frontend=*) UI_DSN="${line#Frontend=}" ;;
+    __missing__=*) warn "GlitchTip project '${line#__missing__=}' not found — bootstrap may not have completed." ;;
+    __nokey__=*) warn "GlitchTip project '${line#__nokey__=}' exists but has no key — odd, inspect manually." ;;
+  esac
+done <<< "$OUTPUT"
+
+if [[ -z "$API_DSN" || -z "$UI_DSN" ]]; then
+  warn "Could not resolve both DSNs (API=${API_DSN:-<missing>} UI=${UI_DSN:-<missing>})."
+  warn "Re-run later once GlitchTip has finished its first-boot bootstrap."
+  exit 0
+fi
+
+# Policy: only write when the .env value is currently empty / missing. A
+# non-empty existing value is the operator's choice — they may have pointed
+# the stack at hosted Sentry or a different GlitchTip instance, and the
+# auto-wire shouldn't silently overwrite that. The trade-off: once a DSN is
+# in place, this script never touches it again, even if it has gone stale
+# (e.g. the GlitchTip Postgres volume was wiped). In that case clear the
+# line in compose/.env and re-run; the script will repopulate it.
+touch "$ENV_FILE"
+CUR_API_DSN="$(grep -E '^SENTRY_DSN=' "$ENV_FILE" | tail -n1 | sed 's/^SENTRY_DSN=//' || true)"
+CUR_UI_DSN="$(grep -E '^VITE_SENTRY_DSN=' "$ENV_FILE" | tail -n1 | sed 's/^VITE_SENTRY_DSN=//' || true)"
+
+WROTE_ANY=0
+upsert_env_if_empty() {
+  local key="$1" value="$2" cur="$3" file="$4"
+  if [[ -n "$cur" ]]; then
+    log "$key already set — leaving as-is (operator override)."
+    return
+  fi
+  if grep -qE "^${key}=" "$file"; then
+    # Key is present but empty — replace the empty value in-place.
+    awk -v k="$key" -v v="$value" 'BEGIN{FS=OFS="="} $1==k {$0=k"="v} {print}' "$file" > "${file}.tmp" \
+      && mv "${file}.tmp" "$file"
+  else
+    printf '\n%s=%s\n' "$key" "$value" >> "$file"
+  fi
+  WROTE_ANY=1
+}
+
+log "Wiring DSNs in ${ENV_FILE#"$ROOT"/}"
+upsert_env_if_empty SENTRY_DSN "$API_DSN" "$CUR_API_DSN" "$ENV_FILE"
+upsert_env_if_empty VITE_SENTRY_DSN "$UI_DSN" "$CUR_UI_DSN" "$ENV_FILE"
+
+if [[ "$WROTE_ANY" == "0" ]]; then
+  log "Both DSNs already set — nothing to do."
+  exit 0
+fi
+
+# Recreate api-dev + ui-dev so they pick up the new env interpolation.
+# `docker compose restart` is NOT enough: it stops + starts the existing
+# container with the env block that was interpolated from .env when the
+# container was first `up`-ed. Only `up -d --force-recreate` re-resolves
+# the env at recreate time.
+#
+# Both services live in the base docker-compose.yml (profiles [dev] /
+# [dev, smoke]), so no overlay is needed — `--profile dev` is enough.
+RECREATABLE=()
+for svc in api-dev ui-dev; do
+  cid="$(docker ps -q \
+    --filter "label=com.docker.compose.project=${PROJECT_NAME}" \
+    --filter "label=com.docker.compose.service=${svc}" \
+    | head -n1)"
+  if [[ -n "$cid" ]]; then
+    RECREATABLE+=("$svc")
+  fi
+done
+
+if (( ${#RECREATABLE[@]} > 0 )); then
+  log "Recreating ${RECREATABLE[*]} to pick up the new DSNs..."
+  if docker compose --profile dev up -d --no-deps --force-recreate "${RECREATABLE[@]}" >/dev/null 2>&1; then
+    log "Recreated: ${RECREATABLE[*]}"
+  else
+    warn "Recreate failed — run manually:"
+    warn "  docker compose --profile dev up -d --no-deps --force-recreate ${RECREATABLE[*]}"
+  fi
+else
+  log "(api-dev / ui-dev not running — they'll read the new env on next up)"
+fi
+
+log "Done. Sentry / GlitchTip wiring is live."


### PR DESCRIPTION
## Summary
- `dev.sh up -d` (dev stack only) now runs `scripts/glitchtip-fetch-dsn.sh` in the background after compose comes up.
- The script waits for `glitchtip-web`, pulls the DSNs for the auto-created `API` / `Frontend` projects via `manage.py shell` (no API auth dance — straight to the Django ORM), writes them into `compose/.env`, and recreates `api-dev` + `ui-dev` so the new env values land.
- Idempotent: only writes when the env value is empty — a pre-set value (hosted Sentry, external GlitchTip) is treated as deliberate operator intent and left alone.
- `docker-compose.yml`: pipes `SENTRY_DSN` to `api-dev` and `VITE_SENTRY_DSN` to `ui-dev` — neither was previously plumbed.
- Docs catch up: `compose/.env.example`, `infra/compose/docs/glitchtip.md`, and the docs site `error-tracking.mdx` drop the manual paste step and the misleading "wire your own Sentry.init" snippet.

Removes the manual "open GlitchTip, copy DSN, paste into env, restart" ritual from hour one. Sentry init no-ops on empty DSN, so a partial or failed wire still leaves the stack bootable — same failure mode as before, but the happy path is now free.

## Test plan
- [x] `apps/docs` builds (67 pages clean)
- [x] Local end-to-end on the dev stack:
  - Auto-wire wrote DSNs into `compose/.env`
  - Recreated api-dev + ui-dev
  - `api-dev` logs show `sentry.initialized` with the resolved DSN and `tracesSampleRate: 0` from PR #55
  - Second invocation no-ops with "already set — leaving as-is"
- [x] Pre-push smoke gate green
- [x] `shellcheck` clean on the new script + the dev.sh delta