### PR TITLE
fix(ci): smoke gate must report a status on every PR (required check)

### DIFF
--- a/.github/workflows/infra-compose-full-stack-smoke.yml
+++ b/.github/workflows/infra-compose-full-stack-smoke.yml
@@ -13,12 +13,15 @@ on:
       - "apps/api/**"
       - "apps/ui/**"
       - ".github/workflows/infra-compose-full-stack-smoke.yml"
+  # Intentionally no `paths:` filter on pull_request: this job is a required
+  # check in branch protection, and a path-filtered workflow that never runs
+  # never reports a status — leaving docs-only PRs perpetually blocked. The
+  # body uses dorny/paths-filter and gates every real step on
+  # `if: steps.filter.outputs.code == 'true'`, so a docs-only PR runs just
+  # the checkout + filter (~30s) and exits success with the required check
+  # name reported green. The full smoke loop only runs when code paths
+  # actually change.
   pull_request:
-    paths:
-      - "infra/compose/**"
-      - "apps/api/**"
-      - "apps/ui/**"
-      - ".github/workflows/infra-compose-full-stack-smoke.yml"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

\`register → login → /me through the full stack\` is a required check in branch protection on \`main\`. The smoke workflow had a \`paths:\` filter on its \`pull_request:\` trigger that excluded docs-only PRs entirely — so for docs PRs the workflow never ran, never reported a status, and branch protection blocked merge forever. PR #58 hit this and had to land via admin override.

The job body already uses \`dorny/paths-filter\` and gates every real step on \`if: steps.filter.outputs.code == 'true'\`. Removing the trigger-level \`paths:\` doesn't waste runner time on docs PRs — they run just the checkout + filter (~30s) and exit success with the required check name reported green. The expensive smoke loop (compose up, Playwright) only runs when code paths actually change.

Keeping the \`push:\` paths filter as-is: we don't want every docs commit on main to fire the smoke loop.

## Test plan
- [x] YAML parses
- [x] This PR itself: a config-only change → the smoke job should run, skip every real step via \`if:\`, and report green for the required check name. (Self-verifying — if this PR can auto-merge without admin override, the fix works.)