### PR TITLE
fix(docs): repoint firewall-and-tls Security link to /topics/security/

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -48,4 +48,10 @@ commits = [
   # `0.5` as a leaked key. The follow-up commit changed the example
   # to use a placeholder; this fingerprint pins the historical hit.
   "9262aa98aebe8b93d055b28a98fb44b72097935b",
+  # Squash-merge of PR #64 (docs full rewrite) carries the same
+  # Meilisearch example line; the placeholder
+  # `MEILI_MASTER_KEY=<set-from-your-secret-manager>` matches the
+  # `generic-api-key` heuristic. The working tree's value is a clear
+  # placeholder, not a real key.
+  "6786314043dc1798aff0a19d803102b3b20b5144",
 ]

--- a/apps/docs/src/content/docs/runbooks/firewall-and-tls.mdx
+++ b/apps/docs/src/content/docs/runbooks/firewall-and-tls.mdx
@@ -97,7 +97,7 @@ Idempotent. Safe to run anytime.
 - **App-layer attacks**: Traefik rate-limit middleware (already configured for the API) and per-account rate limits in the API.
 - **SSH compromise**: Use a non-standard SSH port, disable password auth, use a hardware key.
 
-See [Security hardening](/infra/security/) for a full checklist.
+See [Security](/topics/security/) for a full checklist.
 
 ## Related
 


### PR DESCRIPTION
## Summary
- `runbooks/firewall-and-tls.mdx` linked to `/infra/security/` which doesn't exist; the actual page is `/topics/security/`. Fixes the only error flagged by docs-linkcheck on PR #64.
- Allowlists the PR #64 squash commit in `.gitleaks.toml` for the same Meilisearch placeholder false positive already handled for the source commit.

## Why this slipped past
PR #64 had linkcheck failing visibly, but `docs-linkcheck` wasn't in the required-status-checks list, so auto-merge fired on the required jobs alone. linkcheck has since been added to required checks.

## Test plan
- [x] `cd apps/docs && bun run build` green (67 pages).
- [x] Local broken-internal-link scan returns zero.
- [x] `gitleaks detect` clean with both allowlist entries.
- [ ] CI linkcheck passes (the whole point of this PR).