### PR TITLE
docs: WUD default-on framing + Before you build, Resources pages

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -362,17 +362,23 @@ export default defineConfig({
       },
       lastUpdated: true,
       sidebar: [
-        { label: "Welcome", link: "/" },
-        { label: "Quickstart", link: "/quickstart/" },
         {
-          label: "First feature in 10 minutes",
-          link: "/skills/first-feature-tutorial/",
+          label: "Start here",
+          items: [
+            { label: "Welcome", link: "/" },
+            { label: "Before you build", link: "/before-you-build/" },
+            { label: "Quickstart", link: "/quickstart/" },
+            {
+              label: "First feature in 10 minutes",
+              link: "/skills/first-feature-tutorial/",
+            },
+            {
+              label: "Why BoringStack",
+              link: "/architecture/why-boringstack/",
+            },
+            { label: "Deployment", link: "/topics/deployment/" },
+          ],
         },
-        {
-          label: "Why BoringStack",
-          link: "/architecture/why-boringstack/",
-        },
-        { label: "Deployment", link: "/topics/deployment/" },
         {
           label: "Agent skills",
           items: [
@@ -529,6 +535,7 @@ export default defineConfig({
             { label: "Codecov setup", link: "/runbooks/codecov-setup/" },
           ],
         },
+        { label: "Resources", link: "/resources/" },
       ],
     }),
   ],

--- a/apps/docs/src/content/docs/api/auth.mdx
+++ b/apps/docs/src/content/docs/api/auth.mdx
@@ -1,6 +1,6 @@
 ---
 title: Authentication
-description: HttpOnly cookie auth with short-lived JWT access cookies, DB-backed refresh sessions, bcrypt-hashed passwords, and server-side OAuth.
+description: HttpOnly cookie auth with short-lived JWT access cookies, DB-backed refresh sessions, argon2id-hashed passwords, and server-side OAuth.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -13,7 +13,7 @@ Once verified, the session uses two tokens. An `auth_token` is a 15-minute state
 
 ## Verify-before-account
 
-Password signup splits across two endpoints. `POST /auth/register` writes only the pending user row, the bcrypt hash, and a single-use verification token. No `app.accounts` row, no membership, no session cookies. The response is a `{ message }` envelope so the SPA can render "check your inbox at user@example.com." `POST /auth/verify-email` flips `users.email_verified_at`, atomically calls `provisionAfterVerification`, and _then_ issues the auth + refresh cookies. That's where the user gets their account.
+Password signup splits across two endpoints. `POST /auth/register` writes only the pending user row, the argon2id hash, and a single-use verification token. No `app.accounts` row, no membership, no session cookies. The response is a `{ message }` envelope so the SPA can render "check your inbox at user@example.com." `POST /auth/verify-email` flips `users.email_verified_at`, atomically calls `provisionAfterVerification`, and _then_ issues the auth + refresh cookies. That's where the user gets their account.
 
 ```mermaid
 sequenceDiagram
@@ -93,7 +93,7 @@ One user can hold a password and N OAuth links (two tables: `users` and `user_au
 
 No account exists without a verified email. `/register` writes only the pending user row. The personal account and owner membership are created only at verify-email time, or inline at the OAuth callback when the IdP asserts verified email. Abandoned signups don't leave orphan tenant rows.
 
-On `/login`, the password check order is: dummy-verify on lookup miss, then bcrypt, then check `email_verified_at`. This ensures an attacker who doesn't know the password cannot enumerate pending users by trying to login with unverified addresses.
+On `/login`, the password check order is: dummy-verify on lookup miss, then argon2id verify, then check `email_verified_at`. Legacy bcrypt hashes still verify (so existing users aren't locked out) and get rehashed into argon2id transparently on the next successful login. Constant-shape work on every attempt means an attacker who doesn't know the password can't enumerate pending users by trying to login with unverified addresses.
 
 ## The OAuth round-trip
 

--- a/apps/docs/src/content/docs/architecture/stack.mdx
+++ b/apps/docs/src/content/docs/architecture/stack.mdx
@@ -24,7 +24,7 @@ Runtime and dev dependencies, what each does, and why each piece exists. BoringS
 - **Database: Postgres.** Durable, well-tooled.
 - **Cache + queue store: Valkey.** OSS Redis-protocol fork (BSD-3); drop-in for Redis clients.
 - **Queues: BullMQ.** Canonical Valkey job queue.
-- **Auth.** bcryptjs + short-lived JWT access cookies + DB-backed refresh sessions + Arctic (OAuth).
+- **Auth.** argon2id passwords (via `Bun.password`) + short-lived JWT access cookies + DB-backed refresh sessions + Arctic (OAuth).
 - **Email.** Cloudflare Email (default), Resend, SendGrid, SMTP, noop. SMTP works with Mailpit in dev.
 - **Error tracking.** @sentry/bun → hosted Sentry or self-hosted GlitchTip.
 - **AI.** OpenAI SDK, Anthropic SDK, or noop. `OPENAI_BASE_URL` for compatible endpoints.

--- a/apps/docs/src/content/docs/before-you-build.mdx
+++ b/apps/docs/src/content/docs/before-you-build.mdx
@@ -1,0 +1,77 @@
+---
+title: Before you build
+description: The quality of your product tracks how well you understand your user's pain. Spec the problem before you ship the code.
+---
+
+BoringStack solves the engineering side of shipping a product. Auth, deploys, billing, observability: you don't lose weeks on any of them. What it can't do is tell you what to build. That part is yours, and it's the part that decides whether the whole thing earns money or just sits on GitHub.
+
+This page is the mindset that pairs with the rest of the docs. Read it once, then come back to it whenever you feel the urge to open the editor before you've thought hard about the problem.
+
+## The quality of your product tracks how well you understand your user
+
+One variable beats every other variable: how deeply you understand the pain you're solving. Not your stack choice, not how fast you ship, not how many features you have. If you build for an imagined user, you ship for nobody.
+
+Before you write a line of code, you should be able to answer:
+
+- Whose pain is this? Name three real people who have it.
+- How are they solving it today, badly?
+- What would make them switch to you, and what would stop them?
+- What would they pay for it today, with a credit card?
+
+If any of those answers is "I don't know yet," the next step is talking to people, not typing.
+
+## Measure five times, cut once
+
+The strongest move you have as an engineer in 2026 is spec-driven development with agents. Sit with the problem in writing. Draft the feature as a one-page spec. Then walk an agent (or a friend) through it and watch what they ask. The questions are the gaps.
+
+This is slow. It feels slow. It is also the single highest-return thing you can do with your time. An hour spent narrowing the spec saves a week of building the wrong thing. The temptation to start coding because coding feels productive is the trap. Coding the wrong thing is the most expensive form of productivity there is.
+
+For the broader methodology, [specdriven.com](https://specdriven.com/) is a clear, well-written walkthrough of the practice. For the BoringStack-specific mechanic, see the [spec loop](/skills/spec-loop/) page.
+
+## People pay for four things
+
+When you're deciding what to build, what to price, what to put in the headline, every answer routes through one of four buckets. People pay for:
+
+1. **Time.** They want their hour back.
+2. **Money.** They want more of it, or to stop losing it.
+3. **Sex.** They want to be more attractive, more desired, more chosen.
+4. **Approval and peace of mind.** They want to look good to their boss, their peers, or themselves, and they want to stop worrying about a thing.
+
+Everything else is noise. Every feature, every page, every line of copy should map cleanly to one of these. If it doesn't, cut it. The product that wins is the one where the user can answer "which of the four am I buying" in a single sentence.
+
+## Sell aspirin, not vitamins
+
+People buy aspirin. They buy it the moment they have a headache and they pay whatever it costs. People buy vitamins sometimes, when they remember, after they've finished the rest of their shopping list.
+
+If your product is an aspirin, the user can describe their pain in a sentence and they're already paying for a worse version of it. If it's a vitamin, the most enthusiastic prospect will say "this is interesting, I'll think about it." That gap is the whole game.
+
+Look at what you're building and ask honestly: does the user already pay someone, somewhere, badly, for this? If yes, you have an aspirin. If you have to convince them they should care, you have a vitamin. Vitamins can become aspirins, but only after you find the underlying pain that makes them urgent.
+
+## Build the people, not just the product
+
+A product doesn't sit alone in a market. It sits inside relationships, recommendations, and conversations. The companies that work are the ones where the founder is in the conversation with their users, daily, before there's even a product.
+
+Be useful first. Share what you learn. Answer questions in public. Help people with their problems without expecting anything back. Over a year, this compounds harder than any marketing budget. You become part of the product, because the face is part of the product.
+
+Have a presence somewhere. It doesn't need to be huge. A small audience that trusts you beats a large one that's only seen an ad.
+
+## Further reading
+
+- **The Mom Test** by Rob Fitzpatrick. A short book on how to talk to people about your product without poisoning the answers. The most-recommended-by-founders book for a reason.
+- **["Do Things That Don't Scale"](http://paulgraham.com/ds.html)** by Paul Graham. Why the first hundred users come from manual, unscalable work. Read it before you over-engineer growth.
+- **Talking to Humans** by Giff Constable. Free PDF. Concrete patterns for customer interviews when you don't have a sales background.
+
+## Communities worth your time
+
+- **[Indie Hackers](https://www.indiehackers.com/)**. Where solo and small-team founders share what they're building, what's working, and what isn't. Browse the milestones, not just the front page.
+- **[Hacker News](https://news.ycombinator.com/)**. The technical conversation around launches and stack choices. Show HN is a useful proxy for whether your idea has been built before.
+
+## When you're ready
+
+Open [Quickstart](/quickstart/) and start building. With a spec that holds up to questioning, a clear answer to "which of the four am I selling," and the first three people you're building for already on a call with you, the engineering part is the easy part. That's the part BoringStack is for.
+
+## Related
+
+- [Spec loop](/skills/spec-loop/), the spec-driven workflow for working with agents.
+- [Resources](/resources/), tools and reading that pair well with building a product.
+- [Quickstart](/quickstart/), where the code starts once the spec is ready.

--- a/apps/docs/src/content/docs/infra/profiles-and-overlays.mdx
+++ b/apps/docs/src/content/docs/infra/profiles-and-overlays.mdx
@@ -5,7 +5,7 @@ description: How STACK= and WITH_* flags compose docker-compose files. Observabi
 
 import { Aside } from "@astrojs/starlight/components";
 
-The default stack runs Postgres, Valkey, your apps, plus observability (Prometheus + Grafana + Loki + Promtail) and GlitchTip error tracking. You build muscle memory for the dashboards in dev before prod. Niche overlays (BullMQ, WUD, Mailpit) are opt-in. Traefik runs in prod only; dev uses Vite's proxy. Composition happens in `dev.sh`, which reads `STACK=` and `WITH_*` env vars to assemble the docker-compose command.
+The default stack runs Postgres, Valkey, your apps, plus observability (Prometheus + Grafana + Loki + Promtail) and GlitchTip error tracking. You build muscle memory for the dashboards in dev before prod. WUD (the image-update daemon that powers `git push` deploys) is on by default in prod and off in dev. Niche overlays (BullMQ, Mailpit) are opt-in. Traefik runs in prod only; dev uses Vite's proxy. Composition happens in `dev.sh`, which reads `STACK=` and `WITH_*` env vars to assemble the docker-compose command.
 
 ## How a stack is assembled
 
@@ -17,16 +17,16 @@ flowchart LR
   prod["+ production-labels<br/>traefik · HTTPS · ACME · path routing"]
   obs["+ observability<br/>(default ON)"]
   glitch["+ glitchtip<br/>(default ON)"]
+  wud["+ wud<br/>(default ON in prod)"]
   bullmq["+ bullmq (dev only)"]
-  wud["+ wud"]
   mailpit["+ mailpit (dev only)"]
   base --> stack
   stack -->|dev| dev
   stack -->|prod| prod
   base ==>|on by default| obs
   base ==>|on by default| glitch
+  prod ==>|on by default| wud
   base -.->|WITH_BULLMQ=1| bullmq
-  base -.->|WITH_WUD=1| wud
   base -.->|WITH_MAILPIT=1| mailpit
 ```
 
@@ -34,23 +34,34 @@ The result is a single `docker compose -f ... -f ... --profile ...` command. `de
 
 ## Design choices
 
-- **Observability and GlitchTip default ON.** The whole point of a "production stack" claim is that the operator has seen the dashboards and triaged real errors before prod day-one. Defaults that hide observability contradict the marketing. Opt out with `WITH_OBSERVABILITY=0` or `WITH_GLITCHTIP=0`.
-- **Niche overlays stay opt-in.** Bull-board (no auth), WUD (image-update detection), and Mailpit (local SMTP) are tools you turn on for a specific reason, not surface area everyone needs.
+- **Observability, GlitchTip, and WUD default ON in prod.** Observability and GlitchTip default ON in dev too, so you build muscle memory before prod day-one; WUD only makes sense once you have a registry to pull from, so it's prod-only. Together they cover the three things a `push to main` deploy needs: dashboards, error visibility, and the daemon that actually pulls and recreates the container. Defaults that hide any of these contradict the "deploy and it just works" promise.
+- **Niche overlays stay opt-in.** Bull-board (no auth) and Mailpit (local SMTP) are tools you turn on for a specific reason, not surface area everyone needs.
 - **Separate dev / prod overlays for labels.** HTTPS, ACME, and security headers live in prod-only files.
 - **`WITH_BULLMQ` only valid in dev.** Bull-board has no auth and no place in production.
 - **Profiles plus overlay files (not one giant file).** `docker compose config` stays readable; overlays can be skipped cleanly.
 
-## Overlays
+## On by default
 
-| Flag | Services | Default | Notes |
+These run unless you explicitly turn them off. They're the surface a `push to main` deploy actually needs.
+
+| Env var | Services | Default | Off switch |
 |---|---|---|---|
-| **WITH_OBSERVABILITY=0** | Prometheus, Grafana, Loki, Promtail, Alertmanager, postgres-exporter, node-exporter | ON | Grafana on :3010. Disable to save ~500MB RAM on constrained hosts. |
-| **WITH_GLITCHTIP=0** | Sentry-compatible error tracking | ON | Reuses Postgres (separate glitchtip DB) and Valkey (DB 1). Dev auto-seeds; prod requires secrets. |
-| **WITH_BULLMQ=1** | Bull-board queue UI | OFF (dev only) | Bull-board at bullmq.localhost. No auth; never expose publicly. |
-| **WITH_WUD=1** | Watchtower-like image update daemon | OFF (dev) / ON (prod) | Watches container images for updates. Prod auto-deploys app images; base images notify-only. |
-| **WITH_MAILPIT=1** | Local SMTP catcher | OFF (dev only) | Mailpit at :8025 for development email testing. |
+| `WITH_OBSERVABILITY` | Prometheus, Grafana, Loki, Promtail, Alertmanager, postgres-exporter, node-exporter | ON (dev + prod) | `WITH_OBSERVABILITY=0` |
+| `WITH_GLITCHTIP` | Sentry-compatible error tracking | ON (dev + prod) | `WITH_GLITCHTIP=0` |
+| `WITH_WUD` | What's Up Docker image-update daemon | ON in prod, OFF in dev | `WITH_WUD=0 STACK=prod ./scripts/compose-up.sh` |
 
-Minimal stack: `WITH_OBSERVABILITY=0 WITH_GLITCHTIP=0 ./scripts/compose-up.sh` boots just Postgres + Valkey + apps.
+WUD is what makes `git push origin main` deploy. It polls GHCR, pulls new app image tags, and recreates the container. See [Image updates](/runbooks/image-updates/) for the hybrid policy (app images auto-deploy, base images notify-only).
+
+## Opt-in
+
+These cover specific workflows and stay off until you ask for them.
+
+| Env var | Services | When you'd enable it |
+|---|---|---|
+| `WITH_BULLMQ=1` | Bull-board queue UI | Inspect BullMQ jobs in dev. No auth; never expose publicly. |
+| `WITH_MAILPIT=1` | Local SMTP catcher | Test transactional email in dev without sending to real inboxes. Reaches `:8025`. |
+
+Minimal stack: `WITH_OBSERVABILITY=0 WITH_GLITCHTIP=0 ./scripts/compose-up.sh` boots just Postgres + Valkey + apps. Useful on a constrained host or when you're debugging the base stack itself.
 
 <Aside type="caution" title="Security: BullMQ in production">
 Never run WITH_BULLMQ=1 in a public production environment. The BullMQ dashboard has no authentication.

--- a/apps/docs/src/content/docs/resources.mdx
+++ b/apps/docs/src/content/docs/resources.mdx
@@ -1,0 +1,21 @@
+---
+title: Resources
+description: Command-line tools that pair well with the BoringStack workflow.
+---
+
+A short list of CLI tools that pull their weight when you're working with the stack day to day. Reading and communities live on the [Before you build](/before-you-build/) page, since they belong with the mindset rather than the toolbox.
+
+## Command-line tools
+
+- **[lazydocker](https://github.com/jesseduffield/lazydocker)**. TUI dashboard for Docker. Faster than `docker ps`, `docker logs`, and `docker stats` in three separate tabs. Reach for it whenever something in the compose stack is misbehaving.
+- **[lazygit](https://github.com/jesseduffield/lazygit)**. Same author, same shape, for git. Staging hunks, browsing history, and resolving conflicts without typing `git`.
+- **[1Password CLI (`op`)](https://developer.1password.com/docs/cli/)**. What the deployment docs assume. Keeps secrets in 1Password and injects them at deploy time, so no plaintext credential lives on your disk or in the repo for long.
+- **[gh CLI](https://cli.github.com/)**. Used throughout the docs for PRs, runs, releases, and reading CI status without leaving the terminal.
+- **[ripgrep (`rg`)](https://github.com/BurntSushi/ripgrep)** and **[fd](https://github.com/sharkdp/fd)**. Faster grep and find. First thing to install on a fresh machine.
+- **[jq](https://jqlang.org/)**. JSON wrangling on the command line. Useful for poking the API in dev.
+- **[pgcli](https://www.pgcli.com/)**. Autocompleting Postgres REPL. Replaces `psql` for nearly everything you'd do interactively.
+
+## Related BoringStack pages
+
+- [Before you build](/before-you-build/), the mindset, reading, and communities that pair with the engineering.
+- [Spec loop](/skills/spec-loop/), the spec-driven workflow for working with agents.

--- a/apps/docs/src/content/docs/topics/deployment.mdx
+++ b/apps/docs/src/content/docs/topics/deployment.mdx
@@ -137,13 +137,7 @@ outcome; OpenTofu is faster and reproducible.
 
 ### Path A: OpenTofu (recommended)
 
-Install OpenTofu on your laptop:
-
-```bash
-brew install opentofu   # macOS; see opentofu.org/docs/intro/install for other OSes
-```
-
-Clone your fork and prepare the bootstrap directory:
+Install OpenTofu on your laptop ([install docs](https://opentofu.org/docs/intro/install/)), then clone your fork and prepare the bootstrap directory:
 
 ```bash
 git clone https://github.com/<you>/<your-fork>
@@ -354,26 +348,22 @@ same job.
 When all three checks pass, open `https://<your-domain>` and register
 the first user.
 
-### Post-deploy chores (do this week, not on day one)
+### After the first deploy
 
 - **Rotate the seed superuser password.** If you set `superuser_email` and `superuser_password` in `terraform.tfvars`, log in as that user, open the password-reset flow from **Profile → Security**, and rotate to a fresh value (stash in 1Password under `Production/Superuser/password`). The bootstrap value should never be the long-lived password.
 - **Run a backup-and-restore drill.** [Backups](/runbooks/backups/) covers `pg_dump` plus rclone offsite. The drill: take a backup with the script, drop a non-essential table, restore the backup, confirm the table is back. The first restore on a real outage is the wrong time to discover backup gaps.
 - **Wire alerts.** [Alerts](/topics/alerts/) covers Alertmanager's Slack and Discord receivers. Set `ALERTMANAGER_SLACK_WEBHOOK_URL` or `ALERTMANAGER_WEBHOOK_URL` in `compose/.env`, then `STACK=prod ./scripts/compose-up.sh up -d alertmanager` to apply.
 - **Trigger a test error.** From the VPS: `docker compose exec api bun -e 'throw new Error("first error")'`. The error should appear in GlitchTip within a few seconds. If GlitchTip is fresh, the DSN auto-wiring only runs once on first dev boot, not on prod. Set `SENTRY_DSN` and `VITE_SENTRY_DSN` in `compose/.env` from the GlitchTip project's Client Keys page.
 
-## Day-2 deploys
+## Shipping changes
 
-Code changes under `apps/api` or `apps/ui`: push and let WUD pick the
-new image up.
+To redeploy `apps/api` or `apps/ui`, push to `main`. The release workflow builds and publishes new GHCR images, and WUD on the VPS pulls the new `:latest` within about a minute and recreates the container.
 
 ```bash
 git push origin main
-# release.yml builds and pushes ghcr.io/<you>/<repo>-{api,ui}:latest
-# WUD on the VPS detects the new :latest within about a minute and recreates the container.
 ```
 
-Infra YAML, compose env changes, or anything else under `infra/`:
-`git pull` on the VPS, then bring the stack back up.
+Anything under `infra/` (compose files, env changes, Tofu modules) is git-pulled on the VPS, not auto-deployed. Bring the stack back up after pulling:
 
 ```bash
 ssh root@<vps>


### PR DESCRIPTION
## Summary

### Profiles & overlays (the framing fix that started this)
- Split the overlay table into **On by default** (Observability, GlitchTip, WUD) and **Opt-in** (BullMQ, Mailpit). WUD is what makes `git push` deploys work, so it belongs alongside the other prod defaults, not next to dev-only flags.
- Mermaid diagram + design-choices bullet rewritten to match.

### Deployment page
- OpenTofu install snippet collapsed to a one-line link to the upstream install docs.
- `### Post-deploy chores (do this week, not on day one)` → `### After the first deploy`.
- `## Day-2 deploys` → `## Shipping changes`, intro rewritten in plain English ("push to `main`, WUD pulls the new `:latest` within about a minute").

### New: Before you build
The mindset that pairs with the engineering. Covers:
- Quality of your product tracks how well you understand your user.
- Spec-driven development with agents (measure five times, cut once). Links to [specdriven.com](https://specdriven.com/) for the methodology and the [spec loop](/skills/spec-loop/) page for the BoringStack mechanic.
- The four things people pay for: Time, Money, Sex, Approval/Peace of mind. Everything else is noise.
- Sell aspirin, not vitamins.
- Build relationships alongside the product.
- Further reading (The Mom Test, Paul Graham's "Do Things That Don't Scale", Talking to Humans) and communities (Indie Hackers, HN) live here, since they're mindset-adjacent.

### New: Resources
CLI tools that pull their weight: lazydocker, lazygit, 1Password CLI, gh, ripgrep, fd, jq, pgcli. Tight one-liners per tool, no decoration.

### Sidebar
Wrapped the six previously-orphan top entries (Welcome, Before you build, Quickstart, First feature in 10 minutes, Why BoringStack, Deployment) under a single **Start here** group, so the top of the sidebar is no longer six standalone large headings. Resources appended at the bottom.

## Test plan
- [x] \`bun run build\` green at 69 pages.
- [x] All vocab + em-dash greps return zero on the two new pages.
- [ ] linkcheck on CI (now a required check after the PR #64 incident).