### PR TITLE
fix(ui): unbreak Storybook stories + auth-title sizing + storybook VAPID env

### DIFF
--- a/apps/ui/.storybook/main.ts
+++ b/apps/ui/.storybook/main.ts
@@ -20,6 +20,22 @@ const config: StorybookConfig = {
   },
   docs: {
     defaultName: "Docs"
+  },
+  /*
+   * Inject a synthetic VITE_VAPID_PUBLIC_KEY for Storybook builds so
+   * stories of components that read `env.VITE_VAPID_PUBLIC_KEY` (e.g.
+   * the WebPushCard's "ready to subscribe" state) can actually render
+   * the configured branch. The value is read at module-import time by
+   * `src/lib/env/env.loader.ts`, so it can't be overridden per-story
+   * without restructuring the env module. A dummy P-256 public key is
+   * fine here: stories never call `pushManager.subscribe()`, they only
+   * inspect whether the value is non-empty.
+   */
+  viteFinal(viteConfig) {
+    process.env.VITE_VAPID_PUBLIC_KEY ??=
+      "BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCC395aLN4dRfx-DH3kZBjxg30zCxnT1KMxr2RC_kdNbQ_AVBfBFA";
+
+    return viteConfig;
   }
 };
 

--- a/apps/ui/src/features/accounts/components/SettingsPage/MfaSection/MfaSection.stories.tsx
+++ b/apps/ui/src/features/accounts/components/SettingsPage/MfaSection/MfaSection.stories.tsx
@@ -2,34 +2,70 @@ import type { ReactElement } from "react";
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { I18nextProvider } from "react-i18next";
+
+import { i18n } from "@/lib/i18n/config";
+
+import { AUTH_QUERY_KEYS } from "@/features/auth/Auth.constants";
+import type { IMfaStatusResponse } from "@/features/auth/Auth.types";
 
 import MfaSection from "./MfaSection";
+
+/*
+ * The card's UI state is driven by the `useMfaStatus()` query
+ * (`AUTH_QUERY_KEYS.mfaStatus`). Seeding the cache with different
+ * `{ enabled }` responses lets us render the disabled and enabled
+ * states deterministically without spawning real API requests.
+ *
+ * The "enrolling" state (post-`/auth/mfa/setup`, pre-`/verify-setup`)
+ * is interactive — it's reached by clicking the Enable button and
+ * needs a live mutation round-trip. Skipped here; covered by the
+ * hook + component tests instead.
+ */
+
+function buildClient(status: IMfaStatusResponse | undefined): QueryClient {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  });
+
+  if (status !== undefined) {
+    client.setQueryData(AUTH_QUERY_KEYS.mfaStatus, status);
+  }
+
+  return client;
+}
+
+function withProviders(status: IMfaStatusResponse | undefined) {
+  return (Story: () => ReactElement): ReactElement => (
+    <QueryClientProvider client={buildClient(status)}>
+      <I18nextProvider i18n={i18n}>
+        <Story />
+      </I18nextProvider>
+    </QueryClientProvider>
+  );
+}
 
 const meta: Meta<typeof MfaSection> = {
   title: "Features/Accounts/SettingsPage/MfaSection",
   component: MfaSection,
-  parameters: { layout: "centered" },
-  decorators: [
-    (Story) => {
-      const Wrapper = (): ReactElement => {
-        const client = new QueryClient({
-          defaultOptions: { queries: { retry: false } }
-        });
-
-        return (
-          <QueryClientProvider client={client}>
-            <Story />
-          </QueryClientProvider>
-        );
-      };
-
-      return <Wrapper />;
-    }
-  ]
+  parameters: { layout: "centered" }
 };
 
 export default meta;
 
 type Story = StoryObj<typeof MfaSection>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  name: "Disabled (no second factor)",
+  decorators: [withProviders({ enabled: false })]
+};
+
+export const Loading: Story = {
+  name: "Loading (status not yet resolved)",
+  decorators: [withProviders(undefined)]
+};
+
+export const Enabled: Story = {
+  name: "Enabled (TOTP active)",
+  decorators: [withProviders({ enabled: true })]
+};

--- a/apps/ui/src/features/accounts/components/SettingsPage/WebPushCard.stories.tsx
+++ b/apps/ui/src/features/accounts/components/SettingsPage/WebPushCard.stories.tsx
@@ -1,14 +1,88 @@
+import type { ReactElement } from "react";
+
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { I18nextProvider } from "react-i18next";
+
+import { CAPABILITIES_QUERY_KEY } from "@/lib/api/queries/capabilities.constants";
+import type { ICapabilities } from "@/lib/api/queries/capabilities.types";
+import { i18n } from "@/lib/i18n/config";
 
 import WebPushCard from "./WebPushCard";
 
+/*
+ * The card reads two server-driven facts: `capabilities.features.notifications.webPush`
+ * and the browser env (`VITE_VAPID_PUBLIC_KEY`). The browser-side `useWebPush()` hook
+ * inspects `window.Notification`, `navigator.serviceWorker`, `PushManager` — all of
+ * which exist in Storybook's Vite dev server, so `isSupported` is naturally `true`.
+ *
+ * What we can drive from the story:
+ *   - Server capability via the React Query cache (`CAPABILITIES_QUERY_KEY`).
+ *
+ * What we can't easily fake without mocking the hook directly:
+ *   - "Subscribed" state (needs a registered service worker).
+ *   - "Blocked" state (needs `Notification.permission === "denied"`).
+ *   - "Unsupported" state (needs `Notification`/`PushManager` removed from the
+ *     global window — possible via story decorator but invasive).
+ *
+ * The two stories below cover the realistic dev paths: server hasn't shipped web
+ * push (default) and server-side ready but the operator hasn't subscribed yet.
+ */
+
+function buildClient(capabilities: ICapabilities | null): QueryClient {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  });
+
+  client.setQueryData(CAPABILITIES_QUERY_KEY, capabilities);
+
+  return client;
+}
+
+function withProviders(capabilities: ICapabilities | null) {
+  return (Story: () => ReactElement): ReactElement => (
+    <QueryClientProvider client={buildClient(capabilities)}>
+      <I18nextProvider i18n={i18n}>
+        <Story />
+      </I18nextProvider>
+    </QueryClientProvider>
+  );
+}
+
+const noWebPushCapabilities: ICapabilities = {
+  features: {
+    notifications: { sse: false, webPush: false },
+    billing: { enabled: false },
+    ai: { enabled: false }
+  },
+  oauth: { providers: [] }
+};
+
+const withWebPushCapabilities: ICapabilities = {
+  features: {
+    notifications: { sse: true, webPush: true },
+    billing: { enabled: false },
+    ai: { enabled: false }
+  },
+  oauth: { providers: [] }
+};
+
 const meta: Meta<typeof WebPushCard> = {
   title: "Features/Accounts/SettingsPage/WebPushCard",
-  component: WebPushCard
+  component: WebPushCard,
+  parameters: { layout: "centered" }
 };
 
 export default meta;
 
 type IStory = StoryObj<typeof WebPushCard>;
 
-export const Default: IStory = {};
+export const Default: IStory = {
+  name: "Server not configured for web push",
+  decorators: [withProviders(noWebPushCapabilities)]
+};
+
+export const ReadyToSubscribe: IStory = {
+  name: "Ready to subscribe (server + browser configured)",
+  decorators: [withProviders(withWebPushCapabilities)]
+};

--- a/apps/ui/src/features/auth/components/ForgotPasswordPage/ForgotPasswordPage.tsx
+++ b/apps/ui/src/features/auth/components/ForgotPasswordPage/ForgotPasswordPage.tsx
@@ -31,7 +31,7 @@ const ForgotPasswordPage: FC<IForgotPasswordPageProps> = (props) => {
           <span className='text-primary text-xs font-medium tracking-[0.18em] uppercase'>
             {t("app.name")}
           </span>
-          <h1 className='text-foreground text-4xl leading-[1.05] font-bold tracking-tight md:text-5xl'>
+          <h1 className='text-foreground text-3xl leading-tight font-bold tracking-tight md:text-4xl'>
             {t("auth.forgotPassword.checkEmailTitle")}
           </h1>
           <p className='text-muted-foreground text-base md:text-lg'>
@@ -67,7 +67,7 @@ const ForgotPasswordPage: FC<IForgotPasswordPageProps> = (props) => {
           </span>
           <h1
             id='forgot-password-title'
-            className='text-foreground text-4xl leading-[1.05] font-bold tracking-tight md:text-5xl'
+            className='text-foreground text-3xl leading-tight font-bold tracking-tight md:text-4xl'
           >
             {t("auth.forgotPassword.title")}
           </h1>

--- a/apps/ui/src/features/auth/components/LoginPage/LoginCredentialsForm/LoginCredentialsForm.stories.tsx
+++ b/apps/ui/src/features/auth/components/LoginPage/LoginCredentialsForm/LoginCredentialsForm.stories.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { MemoryRouter } from "react-router-dom";
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useForm } from "react-hook-form";
@@ -9,6 +10,18 @@ const meta: Meta<typeof LoginCredentialsForm> = {
   title: "Features/Auth/LoginPage/LoginCredentialsForm",
   component: LoginCredentialsForm,
   parameters: { layout: "centered" },
+  /*
+   * The form renders <Link> elements (forgot-password, signup) so the
+   * story needs a router context; without it useContext(RouterContext)
+   * returns null and the destructure of `basename` blows up.
+   */
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    )
+  ],
   render: (args) => {
     const RenderForm = (): ReactElement => {
       const form = useForm<{ email: string; password: string }>({

--- a/apps/ui/src/features/auth/components/LoginPage/LoginCredentialsForm/LoginCredentialsForm.tsx
+++ b/apps/ui/src/features/auth/components/LoginPage/LoginCredentialsForm/LoginCredentialsForm.tsx
@@ -55,7 +55,7 @@ const LoginCredentialsForm: FC<ILoginCredentialsFormProps> = ({
         </span>
         <h1
           id='login-title'
-          className='text-foreground text-4xl leading-[1.05] font-bold tracking-tight md:text-5xl'
+          className='text-foreground text-3xl leading-tight font-bold tracking-tight md:text-4xl'
         >
           {t("auth.login.title")}
         </h1>

--- a/apps/ui/src/features/auth/components/OAuthCallbackPage/OAuthCallbackPage.tsx
+++ b/apps/ui/src/features/auth/components/OAuthCallbackPage/OAuthCallbackPage.tsx
@@ -40,7 +40,7 @@ const OAuthCallbackPage: FC = () => {
         <span className='text-primary text-xs font-medium tracking-[0.18em] uppercase'>
           {t("app.name")}
         </span>
-        <h1 className='text-foreground text-4xl leading-[1.05] font-bold tracking-tight md:text-5xl'>
+        <h1 className='text-foreground text-3xl leading-tight font-bold tracking-tight md:text-4xl'>
           {t("auth.oauth.failed.title")}
         </h1>
         {errorMessage !== null ? (

--- a/apps/ui/src/features/auth/components/ResetPasswordPage/ResetPasswordPage.tsx
+++ b/apps/ui/src/features/auth/components/ResetPasswordPage/ResetPasswordPage.tsx
@@ -31,7 +31,7 @@ const ResetPasswordPage: FC<IResetPasswordPageProps> = (props) => {
           <span className='text-primary text-xs font-medium tracking-[0.18em] uppercase'>
             {t("app.name")}
           </span>
-          <h1 className='text-foreground text-4xl leading-[1.05] font-bold tracking-tight md:text-5xl'>
+          <h1 className='text-foreground text-3xl leading-tight font-bold tracking-tight md:text-4xl'>
             {t("auth.resetPassword.invalidTokenTitle")}
           </h1>
           <p className='text-muted-foreground text-base md:text-lg'>
@@ -59,7 +59,7 @@ const ResetPasswordPage: FC<IResetPasswordPageProps> = (props) => {
           <span className='text-primary text-xs font-medium tracking-[0.18em] uppercase'>
             {t("app.name")}
           </span>
-          <h1 className='text-foreground text-4xl leading-[1.05] font-bold tracking-tight md:text-5xl'>
+          <h1 className='text-foreground text-3xl leading-tight font-bold tracking-tight md:text-4xl'>
             {t("auth.resetPassword.successTitle")}
           </h1>
           <p className='text-muted-foreground text-base md:text-lg'>
@@ -95,7 +95,7 @@ const ResetPasswordPage: FC<IResetPasswordPageProps> = (props) => {
           </span>
           <h1
             id='reset-password-title'
-            className='text-foreground text-4xl leading-[1.05] font-bold tracking-tight md:text-5xl'
+            className='text-foreground text-3xl leading-tight font-bold tracking-tight md:text-4xl'
           >
             {t("auth.resetPassword.title")}
           </h1>

--- a/apps/ui/src/features/auth/components/SignUpPage/SignUpPage.tsx
+++ b/apps/ui/src/features/auth/components/SignUpPage/SignUpPage.tsx
@@ -38,7 +38,7 @@ const SignUpPage: FC<ISignUpPageProps> = (props) => {
           <span className='text-muted-foreground text-xs font-medium tracking-[0.16em] uppercase'>
             {t("app.name")}
           </span>
-          <h1 className='text-foreground text-4xl leading-[1.05] font-bold tracking-tight md:text-5xl'>
+          <h1 className='text-foreground text-3xl leading-tight font-bold tracking-tight md:text-4xl'>
             {t("auth.checkEmail.title")}
           </h1>
           <p className='text-muted-foreground text-base md:text-lg'>
@@ -86,7 +86,7 @@ const SignUpPage: FC<ISignUpPageProps> = (props) => {
           </span>
           <h1
             id='signup-title'
-            className='text-foreground text-4xl leading-[1.05] font-bold tracking-tight md:text-5xl'
+            className='text-foreground text-3xl leading-tight font-bold tracking-tight md:text-4xl'
           >
             {t("auth.signup.title")}
           </h1>

--- a/apps/ui/src/features/auth/components/VerifyEmailPage/VerifyEmailPage.tsx
+++ b/apps/ui/src/features/auth/components/VerifyEmailPage/VerifyEmailPage.tsx
@@ -75,7 +75,7 @@ const VerifyEmailPage: FC = () => {
         <span className='text-primary text-xs font-medium tracking-[0.18em] uppercase'>
           {t("app.name")}
         </span>
-        <h1 className='text-foreground text-4xl leading-[1.05] font-bold tracking-tight md:text-5xl'>
+        <h1 className='text-foreground text-3xl leading-tight font-bold tracking-tight md:text-4xl'>
           {heading}
         </h1>
         <p className='text-muted-foreground text-sm break-words md:text-base'>


### PR DESCRIPTION
## Summary

Three classes of UI breakage caught in Storybook review, batched here so they ship together:

### Broken stories (unable to render)
- **`WebPushCard`** stories were bare `export const Default: IStory = {}` with no providers. Component reads `useCapabilities()` (TanStack Query) so the story crashed with *"No QueryClient set"*. Now wrapped with `QueryClientProvider + I18nextProvider`, plus a seeded `CAPABILITIES_QUERY_KEY` for two realistic states: server not configured (Default) vs. server + browser ready (Ready to subscribe).
- **`MfaSection`** had a QueryClient but no `I18nextProvider`, so the card rendered with raw i18n keys. Only had one Default story despite the component having four UI states. Now has three states seeded via `AUTH_QUERY_KEYS.mfaStatus`: Disabled (Default), Loading, Enabled.
- **`LoginCredentialsForm`** renders `<Link to="/forgot-password">` and `<Link to="/signup">`. No router context in the story → *"Cannot destructure property 'basename' of useContext as it is null"*. Wrapped story render in `MemoryRouter`.

### Storybook env wiring
`WebPushCard`'s configured-branch check is `env.VITE_VAPID_PUBLIC_KEY !== ""`, read at module-import time. Per-story decorators can't influence it. Added a Storybook `viteFinal` hook that injects a synthetic placeholder VAPID public key into `process.env` before Vite resolves env, so the "Ready to subscribe" story actually renders the configured branch. Stories never call `pushManager.subscribe()`, so the dummy is never exercised.

### Auth page title sizing
All six auth pages (SignUp, Login form, ForgotPassword, ResetPassword, VerifyEmail, OAuthCallback) used `text-4xl md:text-5xl` for h1. Multi-word titles like "Create your account" wrapped to two lines in the `max-w-md` panel at most viewport widths. Bumped down one notch to `text-3xl md:text-4xl` so every title fits a single line.

## Test plan
- [x] `bun run typecheck` (apps/ui): clean.
- [x] `bun run lint`: clean on the touched files.
- [x] `bun run test` (apps/ui): no regressions.
- [ ] Manual: open Storybook, confirm WebPushCard / MfaSection / LoginCredentialsForm stories render without errors and the new state stories actually differ visually.