### PR TITLE
feat(auth): split anonymous vs unauthorized; recolor email templates

### DIFF
--- a/apps/api/src/api/accounts/accounts.routes.ts
+++ b/apps/api/src/api/accounts/accounts.routes.ts
@@ -12,7 +12,7 @@ import {
   resolveActiveMembership,
   resolveFreshMembership,
 } from "../../middleware/require-active-membership";
-import { createAuthMiddleware } from "../auth/auth.plugin";
+import { requireAuth } from "../auth/auth.plugin";
 
 import { accountsService } from "./accounts.service";
 import {
@@ -39,7 +39,7 @@ import { invitationsService } from "./invitations.service";
 import { joinRequestsService } from "./join-requests.service";
 import { ownershipTransfersService } from "./ownership-transfers.service";
 
-const accountsRoutes = createAuthMiddleware()
+const accountsRoutes = requireAuth()
   .onError(({ code, error, set }) =>
     errorHandler({ code: String(code), error, set })
   )
@@ -492,7 +492,7 @@ const accountsRoutes = createAuthMiddleware()
  * invitee is authenticated but doesn't yet belong to the target
  * account.
  */
-const invitationAcceptRoutes = createAuthMiddleware()
+const invitationAcceptRoutes = requireAuth()
   .onError(({ code, error, set }) =>
     errorHandler({ code: String(code), error, set })
   )
@@ -557,7 +557,7 @@ const invitationAcceptRoutes = createAuthMiddleware()
  * is moving FROM the active account TO a different one, so gating
  * on the current active membership would block the very move.
  */
-const accountSessionRoutes = createAuthMiddleware()
+const accountSessionRoutes = requireAuth()
   .onError(({ code, error, set }) =>
     errorHandler({ code: String(code), error, set })
   )

--- a/apps/api/src/api/auth/auth.plugin.ts
+++ b/apps/api/src/api/auth/auth.plugin.ts
@@ -81,7 +81,77 @@ const translateJwtError = (err: unknown): never => {
   throw ApiErrors.unauthorized("Authentication failed");
 };
 
-export const createAuthMiddleware = () =>
+/**
+ * Shared verify core for the two guards below. Encodes the contract that
+ * `requireAuth` and `tryAuth` only differ on the missing-cookie case:
+ *
+ *  - missing cookie    → returns `null`
+ *  - present + invalid → throws (translated `ApiError`)
+ *  - present + valid   → returns the resolved session
+ *
+ * Anything that throws here is by definition a real authentication
+ * failure (forged/expired/revoked credentials), and both guards surface
+ * it as 401. Only the "no credentials presented at all" branch is what
+ * the two guards interpret differently.
+ */
+const verifyAuthCookie = async (
+  jwt: { verify: (token: string) => Promise<unknown> },
+  cookieValue: unknown
+): Promise<{ user: IUser; accountId: string } | null> => {
+  if (cookieValue === undefined) {
+    return null;
+  }
+
+  if (typeof cookieValue !== "string") {
+    throw ApiErrors.unauthorized("Invalid authentication cookie");
+  }
+
+  try {
+    const verified = await jwt.verify(cookieValue);
+    const parsed = parseAuthJWTPayload(verified);
+
+    if (parsed.kind !== "ok") {
+      throw ApiErrors.unauthorized("Invalid token payload");
+    }
+
+    await assertNotRevoked(parsed);
+
+    const user = await db.query.users.findFirst({
+      where: eq(users.id, parsed.userId),
+    });
+
+    if (!user) {
+      throw ApiErrors.unauthorized("User not found");
+    }
+
+    /*
+     * Tag the active Sentry scope with the user so any error captured
+     * for the rest of this request carries `user.id` + `user.email`.
+     * The Pino mixin also reads this scope to inject `userId` on every
+     * log record, so a Grafana log line and a GlitchTip error event can
+     * be correlated by the same id. No-op when SENTRY_DSN is unset.
+     */
+    Sentry.setUser({ id: user.id, email: user.email });
+
+    return { user, accountId: parsed.accountId };
+  } catch (err: unknown) {
+    return translateJwtError(err);
+  }
+};
+
+/**
+ * Required-auth guard. Use on every endpoint where an anonymous caller
+ * is a programming error or a security boundary — mutations, account
+ * management, billing, etc. The contract:
+ *
+ *  - missing cookie    → 401 `missing_session`
+ *  - present + invalid → 401 `invalid_session`
+ *  - present + valid   → handler runs with `user` + `accountId`
+ *
+ * For endpoints where "anonymous" is an expected, normal state (`/me`,
+ * `/refresh`, `/mfa/status`), reach for `tryAuth` instead.
+ */
+export const requireAuth = () =>
   new Elysia()
     .use(createJWTConfig())
     .derive(
@@ -89,49 +159,48 @@ export const createAuthMiddleware = () =>
         jwt: jwtPlugin,
         cookie,
       }): Promise<{ user: IUser; accountId: string }> => {
-        try {
-          const authCookie = cookie[AUTH_COOKIE_NAME];
+        const session = await verifyAuthCookie(
+          jwtPlugin,
+          cookie[AUTH_COOKIE_NAME]?.value
+        );
 
-          if (authCookie?.value === undefined) {
-            throw ApiErrors.unauthorized("Missing authentication cookie");
-          }
-
-          const cookieValue = authCookie.value;
-
-          if (typeof cookieValue !== "string") {
-            throw ApiErrors.unauthorized("Invalid authentication cookie");
-          }
-
-          const verified = await jwtPlugin.verify(cookieValue);
-          const parsed = parseAuthJWTPayload(verified);
-
-          if (parsed.kind !== "ok") {
-            throw ApiErrors.unauthorized("Invalid token payload");
-          }
-
-          await assertNotRevoked(parsed);
-
-          const user = await db.query.users.findFirst({
-            where: eq(users.id, parsed.userId),
-          });
-
-          if (!user) {
-            throw ApiErrors.unauthorized("User not found");
-          }
-
-          /*
-           * Tag the active Sentry scope with the user so any error
-           * captured for the rest of this request carries `user.id` +
-           * `user.email`. The Pino mixin also reads this scope to inject
-           * `userId` on every log record, so a Grafana log line and a
-           * GlitchTip error event can be correlated by the same id.
-           * No-op when SENTRY_DSN is unset.
-           */
-          Sentry.setUser({ id: user.id, email: user.email });
-
-          return { user, accountId: parsed.accountId };
-        } catch (err: unknown) {
-          return translateJwtError(err);
+        if (session === null) {
+          throw ApiErrors.unauthorized("Missing authentication cookie");
         }
+
+        return session;
+      }
+    );
+
+/**
+ * Best-effort auth guard. Resolves the session if one is presented and
+ * valid; returns `{ user: null, accountId: null }` when no cookie is
+ * presented at all. Still throws 401 when a cookie IS present but the
+ * signature/payload doesn't verify — a forged or expired credential is
+ * a real failure even on a probe endpoint, and the client should treat
+ * it as a forced-logout signal rather than rendering as "anonymous".
+ *
+ * Use only on probe endpoints that a logged-out browser is expected to
+ * hit on initial load. Every other authenticated route should use
+ * `requireAuth`.
+ */
+export const tryAuth = () =>
+  new Elysia()
+    .use(createJWTConfig())
+    .derive(
+      async ({
+        jwt: jwtPlugin,
+        cookie,
+      }): Promise<{ user: IUser | null; accountId: string | null }> => {
+        const session = await verifyAuthCookie(
+          jwtPlugin,
+          cookie[AUTH_COOKIE_NAME]?.value
+        );
+
+        if (session === null) {
+          return { user: null, accountId: null };
+        }
+
+        return session;
       }
     );

--- a/apps/api/src/api/auth/auth.routes.ts
+++ b/apps/api/src/api/auth/auth.routes.ts
@@ -24,13 +24,14 @@ import {
 } from "../../lib/oauth";
 import { now } from "../../lib/time/now";
 import { errorHandler } from "../../middleware/error-handler";
-import { createAuthMiddleware } from "./auth.plugin";
+import { requireAuth } from "./auth.plugin";
 import {
   AuthResponse,
   ChangePasswordSchema,
   ForgotPasswordSchema,
   LoginSchema,
   MessageResponse,
+  RefreshResponse,
   RegisterSchema,
   ResendVerificationSchema,
   ResetPasswordSchema,
@@ -382,8 +383,16 @@ const sessionAndOAuthRoutes = new Elysia()
       const refresh = cookie[REFRESH_COOKIE_NAME];
       const refreshValue = refresh?.value;
 
+      /*
+       * Anonymous probe path: no refresh cookie at all. Treat as a
+       * known-logged-out state instead of a 401 so the UI's initial
+       * boot doesn't paint the browser console (and our telemetry)
+       * with errors. A refresh cookie that IS present but doesn't
+       * verify still surfaces as 401 below — that's a real failure
+       * and the client should react to it.
+       */
       if (typeof refreshValue !== "string" || refreshValue === "") {
-        throw ApiErrors.unauthorized("Missing refresh session");
+        return createSuccessResponse({ user: null });
       }
 
       const result = await sessionService.refresh(refreshValue);
@@ -400,10 +409,11 @@ const sessionAndOAuthRoutes = new Elysia()
       return createSuccessResponse({ user: result.user });
     },
     {
-      response: AuthResponse,
+      response: RefreshResponse,
       detail: {
         tags: ["Authentication"],
-        summary: "Refresh the auth cookie using the refresh session",
+        summary:
+          "Refresh the auth cookie using the refresh session. Anonymous callers receive 200 `{ user: null }`; an invalid/expired refresh cookie surfaces as 401.",
       },
     }
   )
@@ -537,7 +547,7 @@ const sessionAndOAuthRoutes = new Elysia()
     }
   );
 
-const authenticatedAuthRoutes = createAuthMiddleware()
+const authenticatedAuthRoutes = requireAuth()
   .onError(({ code, error, set }) =>
     errorHandler({ code: String(code), error, set })
   )

--- a/apps/api/src/api/auth/auth.schemas.ts
+++ b/apps/api/src/api/auth/auth.schemas.ts
@@ -25,6 +25,22 @@ export const AuthResponse = t.Object({
   timestamp: t.String(),
 });
 
+/*
+ * Refresh has a third state on top of the usual success/failure split:
+ * an anonymous caller (no refresh cookie at all) gets a 200 with
+ * `user: null`. A refresh cookie that exists but doesn't verify is
+ * still a 401 — see `tryAuth` for the matching contract on `/me`.
+ */
+export const RefreshSuccessData = t.Object({
+  user: t.Union([PublicUserSchema, t.Null()]),
+});
+
+export const RefreshResponse = t.Object({
+  success: t.Boolean(),
+  data: RefreshSuccessData,
+  timestamp: t.String(),
+});
+
 export const MessageResponse = t.Object({
   success: t.Boolean(),
   data: t.Object({ message: t.String() }),

--- a/apps/api/src/api/auth/mfa.routes.ts
+++ b/apps/api/src/api/auth/mfa.routes.ts
@@ -9,7 +9,7 @@ import {
 import { ApiErrors, createSuccessResponse } from "../../lib/errors";
 import { buildJWTPayload, createJWTConfig } from "../../lib/jwt";
 import { errorHandler } from "../../middleware/error-handler";
-import { createAuthMiddleware } from "./auth.plugin";
+import { requireAuth, tryAuth } from "./auth.plugin";
 import { AuthResponse, MessageResponse } from "./auth.schemas";
 import { resolveActiveAccountId } from "./auth.utils";
 import {
@@ -128,11 +128,13 @@ const mfaUnauthenticatedRoutes = new Elysia()
   );
 
 /**
- * Authenticated MFA endpoints. Every route requires a valid session
- * cookie; sensitive routes additionally take the password in the body
- * as step-up auth (see `mfaService.assertPasswordValid`).
+ * MFA status probe. Settings pages read this on mount; for anonymous
+ * callers the answer is unambiguously "MFA not enabled" (there's no
+ * user to enable it for). Uses `tryAuth` so an anonymous boot responds
+ * 200 instead of 401, but a present-but-invalid cookie still surfaces
+ * as 401 (matches the contract in `docs/api/auth-contract`).
  */
-const mfaAuthenticatedRoutes = createAuthMiddleware()
+const mfaStatusRoute = tryAuth()
   .onError(({ code, error, set }) =>
     errorHandler({ code: String(code), error, set })
   )
@@ -140,7 +142,7 @@ const mfaAuthenticatedRoutes = createAuthMiddleware()
     "/mfa/status",
     ({ user }) =>
       createSuccessResponse({
-        enabled: user.mfaEnabledAt !== null,
+        enabled: user !== null && user.mfaEnabledAt !== null,
       }),
     {
       response: t.Object({
@@ -150,10 +152,20 @@ const mfaAuthenticatedRoutes = createAuthMiddleware()
       }),
       detail: {
         tags: ["Authentication"],
-        summary: "Report whether MFA is currently enabled for the user",
-        security: [{ cookieAuth: [] }],
+        summary:
+          "Report whether MFA is currently enabled. Anonymous callers get `enabled: false`.",
       },
     }
+  );
+
+/**
+ * Authenticated MFA endpoints. Every route requires a valid session
+ * cookie; sensitive routes additionally take the password in the body
+ * as step-up auth (see `mfaService.assertPasswordValid`).
+ */
+const mfaAuthenticatedRoutes = requireAuth()
+  .onError(({ code, error, set }) =>
+    errorHandler({ code: String(code), error, set })
   )
   .post(
     "/mfa/setup",
@@ -224,6 +236,7 @@ const mfaAuthenticatedRoutes = createAuthMiddleware()
 
 const mfaRoutes = new Elysia()
   .use(mfaUnauthenticatedRoutes)
+  .use(mfaStatusRoute)
   .use(mfaAuthenticatedRoutes);
 
 export default mfaRoutes;

--- a/apps/api/src/api/billing/billing.routes.ts
+++ b/apps/api/src/api/billing/billing.routes.ts
@@ -2,7 +2,7 @@ import { Elysia } from "elysia";
 
 import { ApiErrors, createSuccessResponse } from "../../lib/errors";
 import { errorHandler } from "../../middleware/error-handler";
-import { createAuthMiddleware } from "../auth/auth.plugin";
+import { requireAuth } from "../auth/auth.plugin";
 
 import {
   CreateCheckoutSessionSchema,
@@ -18,7 +18,7 @@ import { resolveBillingAccount } from "./billing.utils";
 
 const billingRoutes = new Elysia()
   .use(
-    createAuthMiddleware()
+    requireAuth()
       .onError(({ code, error, set }) =>
         errorHandler({ code: String(code), error, set })
       )

--- a/apps/api/src/api/dashboard/dashboard.routes.ts
+++ b/apps/api/src/api/dashboard/dashboard.routes.ts
@@ -1,4 +1,4 @@
-import { createAuthMiddleware } from "../auth/auth.plugin";
+import { requireAuth } from "../auth/auth.plugin";
 import { errorHandler } from "../../middleware/error-handler";
 import {
   ActivityPageSchema,
@@ -8,7 +8,7 @@ import {
 import { dashboardService } from "./dashboard.service";
 import { parseDashboardLimit } from "./dashboard.utils";
 
-const dashboardRoutes = createAuthMiddleware()
+const dashboardRoutes = requireAuth()
   .onError(({ code, error, set }) =>
     errorHandler({ code: String(code), error, set })
   )

--- a/apps/api/src/api/notifications/notifications.push.routes.ts
+++ b/apps/api/src/api/notifications/notifications.push.routes.ts
@@ -1,5 +1,5 @@
 import { errorHandler } from "../../middleware/error-handler";
-import { createAuthMiddleware } from "../auth/auth.plugin";
+import { requireAuth } from "../auth/auth.plugin";
 import {
   PushSubscriptionsListResponse,
   SubscribePushBodySchema,
@@ -16,7 +16,7 @@ import { expirationToIso } from "./notifications.push.utils";
  * key is exposed to the UI via the `VITE_VAPID_PUBLIC_KEY` build-time env,
  * not a runtime endpoint here.
  */
-export const notificationsPushRoutes = createAuthMiddleware()
+export const notificationsPushRoutes = requireAuth()
   .onError(({ code, error, set }) =>
     errorHandler({ code: String(code), error, set })
   )

--- a/apps/api/src/api/notifications/notifications.routes.ts
+++ b/apps/api/src/api/notifications/notifications.routes.ts
@@ -1,6 +1,6 @@
 import { notificationPreferencesService } from "../../lib/notifications";
 import { errorHandler } from "../../middleware/error-handler";
-import { createAuthMiddleware } from "../auth/auth.plugin";
+import { requireAuth } from "../auth/auth.plugin";
 import notificationsPushRoutes from "./notifications.push.routes";
 import {
   ListNotificationsQuerySchema,
@@ -16,7 +16,7 @@ import { notificationsService } from "./notifications.service";
 import { notificationsStreamHandler } from "./notifications.sse";
 import { parseNotificationsLimit } from "./notifications.utils";
 
-const notificationsRoutes = createAuthMiddleware()
+const notificationsRoutes = requireAuth()
   .onError(({ code, error, set }) =>
     errorHandler({ code: String(code), error, set })
   )

--- a/apps/api/src/api/users/users.routes.ts
+++ b/apps/api/src/api/users/users.routes.ts
@@ -1,5 +1,7 @@
-import { createAuthMiddleware } from "../auth/auth.plugin";
+import { Elysia } from "elysia";
+
 import { errorHandler } from "../../middleware/error-handler";
+import { requireAuth, tryAuth } from "../auth/auth.plugin";
 
 import {
   MeResponse,
@@ -8,22 +10,40 @@ import {
 } from "./users.schemas";
 import { usersService } from "./users.service";
 
-const usersRoutes = createAuthMiddleware()
+/*
+ * GET /me is a probe — every anonymous boot of the SPA hits it. It
+ * uses `tryAuth` so a missing cookie resolves to `{ user: null }`
+ * (200) rather than a noisy 401. A cookie that's present but invalid
+ * still throws and surfaces as 401 `invalid_session`, which the UI
+ * treats as a forced logout. See `docs/api/auth-contract` for the
+ * full anonymous-vs-unauthorized split.
+ */
+const meRoutes = tryAuth()
   .onError(({ code, error, set }) =>
     errorHandler({ code: String(code), error, set })
   )
   .get(
     "/me",
-    async ({ user, accountId }) => usersService.getMe(user.id, accountId),
+    async ({ user, accountId }) => {
+      if (user === null || accountId === null) {
+        return { user: null };
+      }
+
+      return usersService.getMe(user.id, accountId);
+    },
     {
       response: MeResponse,
       detail: {
         tags: ["Users"],
         summary:
-          "Get the current user, active account, memberships, and resolved features",
-        security: [{ cookieAuth: [] }],
+          "Get the current user, active account, memberships, and resolved features. Returns `{ user: null }` for anonymous callers.",
       },
     }
+  );
+
+const userMutationRoutes = requireAuth()
+  .onError(({ code, error, set }) =>
+    errorHandler({ code: String(code), error, set })
   )
   .patch(
     "/me",
@@ -38,5 +58,7 @@ const usersRoutes = createAuthMiddleware()
       },
     }
   );
+
+const usersRoutes = new Elysia().use(meRoutes).use(userMutationRoutes);
 
 export default usersRoutes;

--- a/apps/api/src/api/users/users.schemas.ts
+++ b/apps/api/src/api/users/users.schemas.ts
@@ -42,7 +42,19 @@ const RuntimeCapabilitiesSchema = t.Object({
   webPush: t.Boolean(),
 });
 
-export const MeResponse = t.Object({
+/*
+ * `/me` is a probe endpoint: a logged-out browser hits it on every
+ * initial paint to discover whether a session exists. The two states
+ * are exposed as a `user`-discriminated union — anonymous responds 200
+ * with `user: null` (everything else absent); authenticated responds
+ * 200 with the full profile. A 401 from `/me` always means the cookie
+ * was present but invalid, which the UI treats as forced-logout.
+ */
+export const MeAnonymousResponse = t.Object({
+  user: t.Null(),
+});
+
+export const MeAuthenticatedResponse = t.Object({
   user: UserProfileResponse,
   account: t.Object({ id: t.String(), name: t.String() }),
   role: RoleSchema,
@@ -52,3 +64,8 @@ export const MeResponse = t.Object({
   authProviders: t.Array(t.String()),
   hasPasswordLogin: t.Boolean(),
 });
+
+export const MeResponse = t.Union([
+  MeAnonymousResponse,
+  MeAuthenticatedResponse,
+]);

--- a/apps/api/src/middleware/error-handler.ts
+++ b/apps/api/src/middleware/error-handler.ts
@@ -28,12 +28,25 @@ const isClientErrorCode = (code: string): boolean =>
   code === ElysiaErrorCodes.PARSE ||
   code === ElysiaErrorCodes.INVALID_COOKIE_SIGNATURE;
 
+/*
+ * Application-thrown `ApiError`s carry their own statusCode and reach
+ * this handler before Elysia gets to tag them with an error code. Any
+ * 4xx from the app layer is by definition client-driven (bad input,
+ * missing auth, forbidden, conflict) — log at `warn` so it doesn't
+ * pollute the error stream alongside genuine 5xx bugs. 5xx still logs
+ * at `error`.
+ */
+const isClientApiError = (error: unknown): boolean =>
+  error instanceof ApiError &&
+  error.statusCode >= 400 &&
+  error.statusCode < 500;
+
 export const errorHandler = ({
   code,
   error,
   set,
 }: IErrorHandlerArgs): IApiErrorResponse => {
-  const isClientError = isClientErrorCode(code);
+  const isClientError = isClientErrorCode(code) || isClientApiError(error);
 
   const basePayload = {
     errorCode: code,

--- a/apps/api/src/middleware/require-platform-admin.ts
+++ b/apps/api/src/middleware/require-platform-admin.ts
@@ -1,4 +1,4 @@
-import { createAuthMiddleware } from "../api/auth/auth.plugin";
+import { requireAuth } from "../api/auth/auth.plugin";
 import { logger } from "../config/logger";
 import { AUDIT_ACTIONS, auditLogService } from "../lib/audit-log";
 import { ApiErrors } from "../lib/errors";
@@ -14,7 +14,7 @@ import { ApiErrors } from "../lib/errors";
  *     .get("/queues", ...)
  */
 export const requirePlatformAdmin = () =>
-  createAuthMiddleware().onBeforeHandle(({ user }) => {
+  requireAuth().onBeforeHandle(({ user }) => {
     if (user.isPlatformAdmin) {
       logger.info("Platform admin check allowed", {
         event: "authz.platform_admin_bypass",

--- a/apps/api/src/templates/email/components/button.hbs
+++ b/apps/api/src/templates/email/components/button.hbs
@@ -9,7 +9,7 @@
     <tr>
         <td align="center" style="padding: 8px 0 24px;">
             <!--[if mso]>
-            <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{url}}" style="height:48px;v-text-anchor:middle;width:200px;" arcsize="10%" stroke="f" fillcolor="#3F7FD1">
+            <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{url}}" style="height:48px;v-text-anchor:middle;width:200px;" arcsize="10%" stroke="f" fillcolor="#15803d">
                 <w:anchorlock/>
                 <center style="color:#ffffff;font-family:Arial,sans-serif;font-size:15px;font-weight:600;">{{text}}</center>
             </v:roundrect>
@@ -17,7 +17,7 @@
             <!--[if !mso]><!-- -->
             <a
                 href="{{url}}"
-                style="display: inline-block; background-color: #3F7FD1; color: #ffffff; text-decoration: none; padding: 14px 32px; border-radius: 6px; font-size: 15px; font-weight: 600; letter-spacing: 0.2px; border: 1px solid #357ABD; mso-hide: all;"
+                style="display: inline-block; background-color: #15803d; color: #ffffff; text-decoration: none; padding: 14px 32px; border-radius: 6px; font-size: 15px; font-weight: 600; letter-spacing: 0.2px; border: 1px solid #16a34a; mso-hide: all;"
             >
                 {{text}}
             </a>

--- a/apps/api/src/templates/email/components/footer.hbs
+++ b/apps/api/src/templates/email/components/footer.hbs
@@ -15,7 +15,7 @@
                     style="width: 30px; height: 1px; background-color: transparent;"
                 ></td>
                 <td
-                    style="width: 60px; height: 1px; background-color: #4A90E2;"
+                    style="width: 60px; height: 1px; background-color: #4ade80;"
                 ></td>
                 <td
                     style="width: 30px; height: 1px; background-color: transparent;"
@@ -33,7 +33,7 @@
         >
             <a
                 href="{{notificationSettingsUrl}}"
-                style="color: #4A90E2; text-decoration: none;"
+                style="color: #4ade80; text-decoration: none;"
             >Notification settings</a>
         </p>
         {{/if}}

--- a/apps/api/src/templates/email/components/header.hbs
+++ b/apps/api/src/templates/email/components/header.hbs
@@ -4,7 +4,7 @@
         style="padding: 32px 40px 24px; text-align: center; border-bottom: 1px solid #3A3A3A; background-color: #2D2D2D; color: #E8E8E8;"
     >
         <div
-            style="color: #4A90E2; font-size: 24px; font-weight: 600; letter-spacing: -0.5px; margin-bottom: 4px; line-height: 1.2;"
+            style="color: #4ade80; font-size: 24px; font-weight: 600; letter-spacing: -0.5px; margin-bottom: 4px; line-height: 1.2;"
         >
             &gt;_ {{appName}}
         </div>
@@ -20,7 +20,7 @@
                     style="width: 20px; height: 2px; background-color: transparent; font-size: 0; line-height: 0;"
                 >&nbsp;</td>
                 <td
-                    style="width: 40px; height: 2px; background-color: #4A90E2; font-size: 0; line-height: 0;"
+                    style="width: 40px; height: 2px; background-color: #4ade80; font-size: 0; line-height: 0;"
                 >&nbsp;</td>
                 <td
                     style="width: 20px; height: 2px; background-color: transparent; font-size: 0; line-height: 0;"

--- a/apps/api/src/templates/email/preview.ts
+++ b/apps/api/src/templates/email/preview.ts
@@ -263,12 +263,12 @@ const generateIndex = (templates: ITemplateMetadata[]): void => {
   <style>
     body { margin: 0; padding: 40px 20px; background: #1a1a1a; color: #E8E8E8; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
     .container { max-width: 1200px; margin: 0 auto; }
-    h1 { color: #4A90E2; font-size: 32px; margin: 0 0 32px; }
+    h1 { color: #4ade80; font-size: 32px; margin: 0 0 32px; }
     section { margin-bottom: 32px; }
     h2 { color: #808080; font-size: 14px; text-transform: uppercase; letter-spacing: 1px; margin: 0 0 16px; padding-bottom: 8px; border-bottom: 1px solid #404040; }
     .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px; }
     .card { background: #2D2D2D; border: 1px solid #404040; border-radius: 8px; padding: 20px; transition: border-color 0.2s; }
-    .card:hover { border-color: #4A90E2; }
+    .card:hover { border-color: #4ade80; }
     .card a { color: #E8E8E8; text-decoration: none; display: block; }
     .name { font-weight: 500; margin-bottom: 8px; }
     .path { font-size: 12px; color: #808080; font-family: monospace; }

--- a/apps/api/src/templates/email/templates/accounts/invitation-created/content.hbs
+++ b/apps/api/src/templates/email/templates/accounts/invitation-created/content.hbs
@@ -17,7 +17,7 @@
     <td align="center" style="padding: 8px 0 24px;">
       <a
         href="{{acceptUrl}}?token={{token}}"
-        style="display: inline-block; background-color: #4A90E2; color: #ffffff; text-decoration: none; padding: 14px 32px; border-radius: 6px; font-size: 15px; font-weight: 500; letter-spacing: 0.2px;"
+        style="display: inline-block; background-color: #15803d; color: #ffffff; text-decoration: none; padding: 14px 32px; border-radius: 6px; font-size: 15px; font-weight: 500; letter-spacing: 0.2px;"
       >
         Accept Invitation
       </a>

--- a/apps/api/src/templates/email/templates/accounts/join-request-created/content.hbs
+++ b/apps/api/src/templates/email/templates/accounts/join-request-created/content.hbs
@@ -15,7 +15,7 @@
     <td align="center" style="padding: 8px 0 24px;">
       <a
         href="{{reviewUrl}}"
-        style="display: inline-block; background-color: #4A90E2; color: #ffffff; text-decoration: none; padding: 14px 32px; border-radius: 6px; font-size: 15px; font-weight: 500; letter-spacing: 0.2px;"
+        style="display: inline-block; background-color: #15803d; color: #ffffff; text-decoration: none; padding: 14px 32px; border-radius: 6px; font-size: 15px; font-weight: 500; letter-spacing: 0.2px;"
       >
         Review request
       </a>

--- a/apps/api/src/templates/email/templates/accounts/ownership-transfer-initiated/content.hbs
+++ b/apps/api/src/templates/email/templates/accounts/ownership-transfer-initiated/content.hbs
@@ -21,7 +21,7 @@
     <td align="center" style="padding: 8px 0 24px;">
       <a
         href="{{acceptUrl}}"
-        style="display: inline-block; background-color: #4A90E2; color: #ffffff; text-decoration: none; padding: 14px 32px; border-radius: 6px; font-size: 15px; font-weight: 500; letter-spacing: 0.2px;"
+        style="display: inline-block; background-color: #15803d; color: #ffffff; text-decoration: none; padding: 14px 32px; border-radius: 6px; font-size: 15px; font-weight: 500; letter-spacing: 0.2px;"
       >
         Review transfer offer
       </a>

--- a/apps/api/src/templates/email/templates/auth/complete-your-signup/content.hbs
+++ b/apps/api/src/templates/email/templates/auth/complete-your-signup/content.hbs
@@ -14,7 +14,7 @@
         <td align="center" style="padding: 8px 0 0;">
             <a
                 href="{{signupUrl}}"
-                style="display: inline-block; background-color: #4A90E2; color: #ffffff; text-decoration: none; padding: 14px 32px; border-radius: 6px; font-size: 15px; font-weight: 500; letter-spacing: 0.2px;"
+                style="display: inline-block; background-color: #15803d; color: #ffffff; text-decoration: none; padding: 14px 32px; border-radius: 6px; font-size: 15px; font-weight: 500; letter-spacing: 0.2px;"
             >
                 Complete Profile
             </a>

--- a/apps/api/src/templates/email/templates/auth/confirm-your-email/content.hbs
+++ b/apps/api/src/templates/email/templates/auth/confirm-your-email/content.hbs
@@ -14,7 +14,7 @@
     <td align="center" style="padding: 8px 0 24px;">
       <a
         href="{{confirmationUrl}}?token={{token}}"
-        style="display: inline-block; background-color: #4A90E2; color: #ffffff; text-decoration: none; padding: 14px 32px; border-radius: 6px; font-size: 15px; font-weight: 500; letter-spacing: 0.2px;"
+        style="display: inline-block; background-color: #15803d; color: #ffffff; text-decoration: none; padding: 14px 32px; border-radius: 6px; font-size: 15px; font-weight: 500; letter-spacing: 0.2px;"
       >
         Confirm Email
       </a>

--- a/apps/api/src/templates/email/templates/auth/reset-password/content.hbs
+++ b/apps/api/src/templates/email/templates/auth/reset-password/content.hbs
@@ -15,7 +15,7 @@
     <td align="center" style="padding: 8px 0 24px;">
       <a
         href="{{resetUrl}}?token={{token}}"
-        style="display: inline-block; background-color: #4A90E2; color: #ffffff; text-decoration: none; padding: 14px 32px; border-radius: 6px; font-size: 15px; font-weight: 500; letter-spacing: 0.2px;"
+        style="display: inline-block; background-color: #15803d; color: #ffffff; text-decoration: none; padding: 14px 32px; border-radius: 6px; font-size: 15px; font-weight: 500; letter-spacing: 0.2px;"
       >
         Reset Password
       </a>
@@ -33,7 +33,7 @@
     Manage your account settings in your
     <a
       href="{{dashboardUrl}}"
-      style="color: #4A90E2; text-decoration: none;"
+      style="color: #4ade80; text-decoration: none;"
     >dashboard</a>.
   </p>
 {{/if}}

--- a/apps/api/src/templates/email/templates/notifications/generic-notification/content.hbs
+++ b/apps/api/src/templates/email/templates/notifications/generic-notification/content.hbs
@@ -28,7 +28,7 @@
         <td align="center" style="padding: 8px 0 0;">
             <a
                 href="{{target.url}}"
-                style="display: inline-block; background-color: #4A90E2; color: #ffffff; text-decoration: none; padding: 14px 32px; border-radius: 6px; font-size: 15px; font-weight: 500; letter-spacing: 0.2px;"
+                style="display: inline-block; background-color: #15803d; color: #ffffff; text-decoration: none; padding: 14px 32px; border-radius: 6px; font-size: 15px; font-weight: 500; letter-spacing: 0.2px;"
             >
                 {{ctaText}}
             </a>

--- a/apps/api/tests/api/auth/auth.routes.test.ts
+++ b/apps/api/tests/api/auth/auth.routes.test.ts
@@ -302,12 +302,29 @@ describe("auth flow — register → verify → login → me → logout", () => 
 
     expect(logoutRes.status).toBe(200);
 
-    // 8. /me without the cookie → 401
+    /*
+     * 8. /me without the cookie → 200 `{ user: null }`. The endpoint is
+     * a probe; logged-out callers get a known anonymous state, not a
+     * 401. The forced-logout signal (cookie present but invalid) is
+     * covered separately by the tampered-cookie test below.
+     */
     const unauthRes = await app.handle(
       new Request("http://localhost/api/v1/users/me")
     );
 
-    expect(unauthRes.status).toBe(401);
+    expect(unauthRes.status).toBe(200);
+
+    const unauthBody: unknown = await unauthRes.json();
+
+    if (
+      unauthBody === null ||
+      typeof unauthBody !== "object" ||
+      !("user" in unauthBody)
+    ) {
+      throw new Error("/me anonymous response missing `user` field");
+    }
+
+    expect(unauthBody.user).toBeNull();
   });
 
   test("login with wrong password → 401", async () => {
@@ -427,6 +444,62 @@ describe("auth flow — register → verify → login → me → logout", () => 
     const body = await readJson(res);
 
     expect(JSON.stringify(body)).toContain("EMAIL_NOT_VERIFIED");
+  });
+});
+
+describe("POST /api/v1/auth/refresh — anonymous-vs-unauthorized contract", () => {
+  beforeEach(async () => {
+    if (!(await requireDb())) {
+      return;
+    }
+
+    await cleanDatabase();
+  });
+
+  test("no refresh cookie → 200 `{ user: null }` (anonymous probe, not a failure)", async () => {
+    if (!(await requireDb())) {
+      return;
+    }
+
+    const app = createApp();
+    const res = await app.handle(
+      new Request("http://localhost/api/v1/auth/refresh", {
+        method: "POST",
+      })
+    );
+
+    expect(res.status).toBe(200);
+
+    const body: unknown = await res.json();
+
+    if (
+      body === null ||
+      typeof body !== "object" ||
+      !("data" in body) ||
+      body.data === null ||
+      typeof body.data !== "object" ||
+      !("user" in body.data)
+    ) {
+      throw new Error("/refresh anonymous response missing `data.user`");
+    }
+
+    expect(body.data.user).toBeNull();
+  });
+
+  test("present-but-invalid refresh cookie → 401 (forged credentials are a real failure)", async () => {
+    if (!(await requireDb())) {
+      return;
+    }
+
+    const app = createApp();
+    const res = await app.handle(
+      new Request("http://localhost/api/v1/auth/refresh", {
+        method: "POST",
+        headers: { cookie: "refresh_token=this-is-not-a-real-session" },
+      })
+    );
+
+    expect(res.status).toBe(401);
   });
 });
 

--- a/apps/api/tests/api/auth/mfa.routes.test.ts
+++ b/apps/api/tests/api/auth/mfa.routes.test.ts
@@ -290,3 +290,56 @@ describe("MFA routes", () => {
     expect(res.headers.get("set-cookie") ?? "").toContain(AUTH_COOKIE_NAME);
   });
 });
+
+describe("GET /api/v1/auth/mfa/status — anonymous-vs-unauthorized contract", () => {
+  beforeEach(async () => {
+    if (!(await requireDb())) {
+      return;
+    }
+
+    await cleanDatabase();
+  });
+
+  test("no auth cookie → 200 `{ enabled: false }` (anonymous probe)", async () => {
+    if (!(await requireDb())) {
+      return;
+    }
+
+    const app = createApp();
+    const res = await app.handle(
+      new Request("http://localhost/api/v1/auth/mfa/status")
+    );
+
+    expect(res.status).toBe(200);
+
+    const body: unknown = await res.json();
+
+    if (
+      body === null ||
+      typeof body !== "object" ||
+      !("data" in body) ||
+      body.data === null ||
+      typeof body.data !== "object" ||
+      !("enabled" in body.data)
+    ) {
+      throw new Error("/mfa/status anonymous response missing `data.enabled`");
+    }
+
+    expect(body.data.enabled).toBe(false);
+  });
+
+  test("present-but-invalid auth cookie → 401 (forged credentials still reject)", async () => {
+    if (!(await requireDb())) {
+      return;
+    }
+
+    const app = createApp();
+    const res = await app.handle(
+      new Request("http://localhost/api/v1/auth/mfa/status", {
+        headers: { cookie: "auth_token=this-is-not-a-real-jwt" },
+      })
+    );
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/api/tests/api/users/users.routes.test.ts
+++ b/apps/api/tests/api/users/users.routes.test.ts
@@ -116,7 +116,7 @@ describe("GET /api/v1/users/me", () => {
     expect(typeof body.capabilities.notificationsSse).toBe("boolean");
   });
 
-  test("returns 401 with no auth cookie", async () => {
+  test("returns 200 + { user: null } when no auth cookie is presented (anonymous probe)", async () => {
     if (!(await requireDb())) {
       return;
     }
@@ -124,10 +124,24 @@ describe("GET /api/v1/users/me", () => {
     const app = createApp();
     const res = await app.handle(new Request(ME_URL));
 
-    expect(res.status).toBe(401);
+    /*
+     * `/me` is a probe — a logged-out browser hits it on every initial
+     * paint. Treating no-credentials as a known anonymous state keeps
+     * the noise off the browser console and out of telemetry. The
+     * present-but-invalid case below still 401s.
+     */
+    expect(res.status).toBe(200);
+
+    const body: unknown = await res.json();
+
+    if (body === null || typeof body !== "object" || !("user" in body)) {
+      throw new Error("/me anonymous response missing `user` field");
+    }
+
+    expect(body.user).toBeNull();
   });
 
-  test("returns 401 with a malformed/tampered auth cookie (Elysia INVALID_COOKIE_SIGNATURE → 401, not 500)", async () => {
+  test("still 401s with a malformed/tampered auth cookie (present-but-invalid is a real failure)", async () => {
     if (!(await requireDb())) {
       return;
     }

--- a/apps/api/tests/middleware/error-handler.test.ts
+++ b/apps/api/tests/middleware/error-handler.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 
+import { logger } from "../../src/config/logger";
 import { errorHandler } from "../../src/middleware/error-handler";
 import { ApiError, ApiErrors } from "../../src/lib/errors";
 
@@ -134,5 +135,68 @@ describe("errorHandler", () => {
 
     expect(set.status).toBe(400);
     expect(body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  test("ApiError(401) is logged at warn — not error — so anonymous-probe noise doesn't masquerade as server bugs", () => {
+    const warnSpy = spyOn(logger, "warn");
+    const errorSpy = spyOn(logger, "error");
+
+    try {
+      const set: ISet = {};
+
+      errorHandler({
+        code: "UNAUTHORIZED",
+        error: ApiErrors.unauthorized("Invalid token"),
+        set,
+      });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  test("ApiError(403) is logged at warn (forbidden is client-driven, not a server bug)", () => {
+    const warnSpy = spyOn(logger, "warn");
+    const errorSpy = spyOn(logger, "error");
+
+    try {
+      const set: ISet = {};
+
+      errorHandler({
+        code: "FORBIDDEN",
+        error: ApiErrors.forbidden(),
+        set,
+      });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
+  test("ApiError(500) still logs at error (a 5xx is a genuine server bug)", () => {
+    const warnSpy = spyOn(logger, "warn");
+    const errorSpy = spyOn(logger, "error");
+
+    try {
+      const set: ISet = {};
+
+      errorHandler({
+        code: "INTERNAL_SERVER_ERROR",
+        error: new ApiError("INTERNAL_SERVER_ERROR", "boom", 500),
+        set,
+      });
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/apps/api/tests/middleware/require-active-membership.test.ts
+++ b/apps/api/tests/middleware/require-active-membership.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { Elysia } from "elysia";
 
 import { seedVerifiedUser } from "../helpers/auth";
-import { createAuthMiddleware } from "../../src/api/auth/auth.plugin";
+import { requireAuth } from "../../src/api/auth/auth.plugin";
 import { env } from "../../src/config/env";
 import { AUTH_COOKIE_NAME } from "../../src/lib/cookies";
 import { errorHandler } from "../../src/middleware/error-handler";
@@ -80,7 +80,7 @@ const buildProbeApp = () =>
       sign: [AUTH_COOKIE_NAME],
     },
   }).use(
-    createAuthMiddleware()
+    requireAuth()
       .onError(({ code, error, set }) =>
         errorHandler({ code: String(code), error, set })
       )
@@ -211,7 +211,7 @@ describe("requireActiveMembership middleware", () => {
         sign: [AUTH_COOKIE_NAME],
       },
     }).use(
-      createAuthMiddleware()
+      requireAuth()
         .onError(({ code, error, set }) =>
           errorHandler({ code: String(code), error, set })
         )
@@ -291,7 +291,7 @@ const buildFreshProbeApp = () =>
       sign: [AUTH_COOKIE_NAME],
     },
   }).use(
-    createAuthMiddleware()
+    requireAuth()
       .onError(({ code, error, set }) =>
         errorHandler({ code: String(code), error, set })
       )

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -424,6 +424,7 @@ export default defineConfig({
           items: [
             { label: "Overview", link: "/api/overview/" },
             { label: "Authentication", link: "/api/auth/" },
+            { label: "Anonymous vs unauthorized", link: "/api/auth-contract/" },
             { label: "Two-factor authentication", link: "/api/mfa/" },
             { label: "Billing", link: "/api/billing/" },
             { label: "Email", link: "/api/email/" },

--- a/apps/docs/src/content/docs/api/auth-contract.mdx
+++ b/apps/docs/src/content/docs/api/auth-contract.mdx
@@ -1,0 +1,144 @@
+---
+title: Anonymous vs unauthorized
+description: The two auth guards (`requireAuth`, `tryAuth`) and how probe endpoints distinguish "no credentials" from "bad credentials" so anonymous boots don't pollute the browser console or telemetry.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+A logged-out browser hits at least three endpoints on initial paint — `/api/v1/users/me`, `/api/v1/auth/refresh`, `/api/v1/auth/mfa/status`. If all three return 401 for the anonymous case, three things break:
+
+1. **Browser DevTools** colors every initial-load network row red — looks like the app is broken.
+2. **Pino** logs each 401 at `error` level — fills GlitchTip and the Grafana logs view with what is in fact normal anonymous traffic.
+3. **Prometheus** tags every probe with `status="401"` — the API dashboard's `4xx` bucket spikes on every cold visit.
+
+The API splits the two cases that 401 used to conflate:
+
+- **Anonymous** — no credentials presented. Expected, recurring, not a failure. Returns 200 with a null-shaped body.
+- **Unauthorized** — credentials presented but invalid (tampered, expired, revoked, wrong issuer). A real failure worth logging. Returns 401 with `invalid_session`.
+
+## Two guards
+
+`apps/api/src/api/auth/auth.plugin.ts` exports two middleware factories. Both share the same JWT-verify core; they only diverge on the missing-cookie case.
+
+```ts
+// Use on every endpoint that should refuse anonymous callers.
+export const requireAuth = () => /* ... */;
+
+// Use on probe endpoints where "anonymous" is a known, normal state.
+export const tryAuth = () => /* ... */;
+```
+
+| State                                             | `requireAuth`                         | `tryAuth`                                               |
+| ------------------------------------------------- | ------------------------------------- | ------------------------------------------------------- |
+| No cookie                                         | **401** `missing_session`             | **200** with `user: null` derived; handler decides body |
+| Cookie present, invalid signature/expired/revoked | **401** `invalid_session`             | **401** `invalid_session`                               |
+| Cookie present, valid                             | handler runs with `user`, `accountId` | handler runs with `user`, `accountId`                   |
+
+The "present but invalid" branch is identical on purpose. A forged cookie is a real failure regardless of which guard the route uses; the client should treat it as a forced-logout signal, not render it as "anonymous".
+
+## The probe endpoints
+
+Three routes use `tryAuth` today:
+
+### `GET /api/v1/users/me`
+
+```http
+GET /api/v1/users/me
+  (no cookie)
+→ 200 OK
+  { "user": null }
+```
+
+```http
+GET /api/v1/users/me
+  Cookie: auth_token=<valid jwt>
+→ 200 OK
+  { "user": { "id": ..., "email": ..., ... },
+    "account": { "id": ..., "name": ... },
+    "role": "owner",
+    "memberships": [...],
+    "features": {...},
+    "capabilities": {...},
+    "authProviders": [...],
+    "hasPasswordLogin": true }
+```
+
+```http
+GET /api/v1/users/me
+  Cookie: auth_token=tampered
+→ 401 Unauthorized
+  { "success": false, "error": { "code": "UNAUTHORIZED", "message": "..." } }
+```
+
+The response is a discriminated union on `user`. UI code branches once:
+
+```ts
+const { data } = await apiClient.GET("/api/v1/users/me");
+if (data == null || data.user === null) {
+  return null; // anonymous → show login
+}
+return data; // authenticated → IMe shape
+```
+
+### `POST /api/v1/auth/refresh`
+
+```http
+POST /api/v1/auth/refresh
+  (no cookie)
+→ 200 OK
+  { "success": true, "data": { "user": null }, "timestamp": "..." }
+```
+
+```http
+POST /api/v1/auth/refresh
+  Cookie: refresh_token=<valid opaque token>
+→ 200 OK with new auth+refresh Set-Cookie
+  { "success": true, "data": { "user": {...} }, "timestamp": "..." }
+```
+
+An expired or unknown refresh cookie still 401s — the rotation logic in `sessionService.refresh` throws when it can't find the session row, and that's the right answer for a credential that won't verify.
+
+### `GET /api/v1/auth/mfa/status`
+
+```http
+GET /api/v1/auth/mfa/status
+  (no cookie)
+→ 200 OK
+  { "success": true, "data": { "enabled": false }, "timestamp": "..." }
+```
+
+For an anonymous caller MFA status is unambiguously "not enabled" — there's no user to enable it for. Settings pages can mount this query on first paint without caring whether the user is logged in yet.
+
+## Pino log level
+
+`apps/api/src/middleware/error-handler.ts` ships every thrown `ApiError` to Pino. Application 4xx errors (the remaining 401s, plus 403, 404, 409, 422 from any route) log at `warn`. 5xx logs at `error`.
+
+```ts
+const isClientApiError = (error: unknown): boolean =>
+  error instanceof ApiError &&
+  error.statusCode >= 400 &&
+  error.statusCode < 500;
+```
+
+Pino's `error` channel feeds GlitchTip's "errors" view by default. Without this split, every anonymous 401 would create a new error group; with it, only genuine server bugs land there.
+
+## Picking a guard
+
+When wiring a new route, ask: **what does a logged-out browser hitting this endpoint mean?**
+
+- If the answer is "it's a bug or a security boundary" — `requireAuth`. This is the default. Mutations, billing, account management, anything destructive.
+- If the answer is "the SPA hits this on first paint to discover whether a session exists" — `tryAuth`. This is rare: today only `/me`, `/refresh`, `/mfa/status`. Don't reach for it just to silence a 401; reach for it when anonymous is a legitimate state the route needs to model.
+
+A `tryAuth` route's handler MUST branch on `ctx.user === null` and return a sensible null-shaped body. Forgetting the branch turns the route into a server error: `requireAuth`-typed handler code can't safely run with a `null` user.
+
+## Telemetry impact
+
+Existing dashboards that filter on `status_code >= 400` will see a measurable drop on `/me`, `/refresh`, and `/mfa/status` after this change. That's not a regression — those status codes were anonymous-probe traffic, not failures. If a 4xx panel previously looked busy on cold-boot and now looks empty, that's the correct outcome.
+
+The forensic signal you actually want — "credentials were presented but rejected" — is now isolated and observable cleanly:
+
+```promql
+rate(http_requests_total{status="401", route=~"/api/v1/(users/me|auth/refresh|auth/mfa/status)"}[5m])
+```
+
+A spike there is meaningful (someone is sending bad cookies); a flat zero is the baseline you should see in steady-state production.

--- a/apps/docs/src/content/docs/topics/tracing.mdx
+++ b/apps/docs/src/content/docs/topics/tracing.mdx
@@ -13,8 +13,6 @@ Generate a slow request and find it in Grafana. Open Grafana → Explore → Tem
 
 ## What's traced
 
-## What's traced
-
 The API initializes an OpenTelemetry SDK (`src/config/otel/`) before any other module imports. Auto-instrumentation patches several libraries at load time. The resulting spans flow through OTLP/HTTP to Tempo.
 
 ### Incoming HTTP (Elysia routes)

--- a/apps/ui/src/features/auth/Auth.queries.test.tsx
+++ b/apps/ui/src/features/auth/Auth.queries.test.tsx
@@ -36,6 +36,19 @@ function wrapper() {
 
 const USER = makeUser({ firstName: "Demo", lastName: "User" });
 
+const ME_PAYLOAD = {
+  user: USER,
+  account: { id: "acc-1", name: "Demo Account" },
+  role: "owner" as const,
+  memberships: [
+    { accountId: "acc-1", accountName: "Demo Account", role: "owner" as const }
+  ],
+  features: { can_export: true, can_invite_team: true, max_seats: 5 },
+  capabilities: { billing: false, notificationsSse: true, webPush: true },
+  authProviders: ["local"],
+  hasPasswordLogin: true
+};
+
 const VALID_LOGIN: ILoginInput = {
   email: "demo@example.com",
   password: "password123"
@@ -59,14 +72,27 @@ describe("useMe", () => {
     expect(result.current.data).toBeNull();
   });
 
-  it("returns the user when the API responds 200", async () => {
-    apiMock.GET.mockResolvedValueOnce({ data: USER, response: {} });
+  it("returns the full session payload when the API responds 200 with the authenticated shape", async () => {
+    apiMock.GET.mockResolvedValueOnce({ data: ME_PAYLOAD, response: {} });
     const { result } = renderHook(() => useMe(), { wrapper: wrapper() });
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
     });
-    expect(result.current.data).toEqual(USER);
+    expect(result.current.data).toEqual(ME_PAYLOAD);
+  });
+
+  it("returns null when the API responds 200 `{ user: null }` (anonymous probe)", async () => {
+    apiMock.GET.mockResolvedValueOnce({
+      data: { user: null },
+      response: {}
+    });
+    const { result } = renderHook(() => useMe(), { wrapper: wrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toBeNull();
   });
 
   it("returns null when the response data is absent", async () => {

--- a/apps/ui/src/features/auth/Auth.queries.ts
+++ b/apps/ui/src/features/auth/Auth.queries.ts
@@ -4,6 +4,7 @@ import { ApiError } from "@/lib/api/ApiError";
 import { apiClient } from "@/lib/api/client";
 
 import { AUTH_QUERY_KEYS } from "./Auth.constants";
+import { isAuthenticatedMe } from "./Auth.queries.utils";
 import type { IMe, IMfaStatusResponse } from "./Auth.types";
 
 export function useMe(): UseQueryResult<IMe | null> {
@@ -13,16 +14,17 @@ export function useMe(): UseQueryResult<IMe | null> {
       try {
         const { data } = await apiClient.GET("/api/v1/users/me");
 
-        return data ?? null;
+        return isAuthenticatedMe(data) ? data : null;
       } catch (error) {
         /*
-         * 401/403 → not authenticated → null → ProtectedRoute redirects
-         * to /login. Network-class failures (no ApiError instance — fetch
-         * threw before we got a response) get the same treatment so a
+         * A 401/403 here means the cookie was present but didn't verify
+         * (forged, expired, revoked). Resolve to `null` so
+         * `ProtectedRoute` redirects to /login — the forced-logout
+         * surfaces as the same UX as anonymous, which is the right
+         * outcome. Network-class failures get the same treatment so a
          * transient outage doesn't crash into RouteErrorBoundary; the
-         * background refetch recovers once connectivity returns.
-         *
-         * Real 4xx (other than auth) and any 5xx propagate — those are
+         * background refetch recovers once connectivity returns. Real
+         * 4xx (other than auth) and any 5xx propagate — those are
          * server bugs the operator needs to see, not "send the user to
          * login and hide the problem."
          */

--- a/apps/ui/src/features/auth/Auth.queries.utils.test.ts
+++ b/apps/ui/src/features/auth/Auth.queries.utils.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { isAuthenticatedMe } from "./Auth.queries.utils";
+
+describe("isAuthenticatedMe", () => {
+  it("returns false for null", () => {
+    expect(isAuthenticatedMe(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isAuthenticatedMe(undefined)).toBe(false);
+  });
+
+  it("returns false for non-object primitives", () => {
+    expect(isAuthenticatedMe("string")).toBe(false);
+    expect(isAuthenticatedMe(42)).toBe(false);
+    expect(isAuthenticatedMe(true)).toBe(false);
+  });
+
+  it("returns false when `user` key is absent (openapi-fetch empty-content branch)", () => {
+    expect(isAuthenticatedMe({})).toBe(false);
+    expect(isAuthenticatedMe({ account: { id: "a", name: "A" } })).toBe(false);
+  });
+
+  it("returns false for the anonymous shape `{ user: null }`", () => {
+    expect(isAuthenticatedMe({ user: null })).toBe(false);
+  });
+
+  it("returns true when `user` is a non-null object (authenticated shape)", () => {
+    expect(
+      isAuthenticatedMe({
+        user: {
+          id: "u1",
+          email: "x@y.com",
+          firstName: "X",
+          lastName: "Y",
+          emailVerified: true,
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z"
+        },
+        account: { id: "a1", name: "Acme" },
+        role: "owner",
+        memberships: [],
+        features: { can_export: true, can_invite_team: true, max_seats: 5 },
+        capabilities: {
+          billing: false,
+          notificationsSse: true,
+          webPush: true
+        },
+        authProviders: ["local"],
+        hasPasswordLogin: true
+      })
+    ).toBe(true);
+  });
+});

--- a/apps/ui/src/features/auth/Auth.queries.utils.ts
+++ b/apps/ui/src/features/auth/Auth.queries.utils.ts
@@ -1,0 +1,17 @@
+import type { IMe } from "./Auth.types";
+
+/*
+ * `/api/v1/users/me` returns a discriminated union: `{ user: null }` for
+ * anonymous callers and the full session payload for authenticated ones.
+ * openapi-fetch widens the response type with empty-content-type branches
+ * which makes direct field narrowing brittle — this typeguard collapses
+ * the messy union to a clean `IMe | null` decision.
+ */
+export function isAuthenticatedMe(data: unknown): data is IMe {
+  return (
+    data !== null &&
+    typeof data === "object" &&
+    "user" in data &&
+    data.user !== null
+  );
+}

--- a/apps/ui/src/features/auth/Auth.types.ts
+++ b/apps/ui/src/features/auth/Auth.types.ts
@@ -48,15 +48,18 @@ export type IMfaRecoveryCodesResponse = z.infer<
 export type IMfaStatusResponse = z.infer<typeof mfaStatusResponseSchema>;
 
 /*
- * /api/v1/users/me is the canonical authenticated-session payload. Shape is
- * pulled from the OpenAPI operation rather than restated in Zod because the
- * server owns the contract.
+ * /api/v1/users/me is a probe endpoint: it returns `{ user: null }` for
+ * anonymous callers and the full session payload otherwise. Shape is
+ * pulled from the OpenAPI operation rather than restated in Zod because
+ * the server owns the contract. `IMe` extracts the authenticated branch
+ * — the `null` branch is handled at the query layer (see
+ * `useMe()` in `Auth.queries.ts`).
  */
 type MeResponse =
   operations["getApiV1UsersMe"]["responses"][200]["content"]["application/json"];
 
-export type IMe = MeResponse;
-export type IMembershipRole = MeResponse["role"];
-export type IAccountSummary = MeResponse["account"];
-export type IMembershipSummary = MeResponse["memberships"][number];
-export type IResolvedFeatures = MeResponse["features"];
+export type IMe = Extract<MeResponse, { user: object }>;
+export type IMembershipRole = IMe["role"];
+export type IAccountSummary = IMe["account"];
+export type IMembershipSummary = IMe["memberships"][number];
+export type IResolvedFeatures = IMe["features"];

--- a/apps/ui/src/lib/api/schema.d.ts
+++ b/apps/ui/src/lib/api/schema.d.ts
@@ -258,7 +258,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Refresh the auth cookie using the refresh session */
+        /** Refresh the auth cookie using the refresh session. Anonymous callers receive 200 `{ user: null }`; an invalid/expired refresh cookie surfaces as 401. */
         post: operations["postApiV1AuthRefresh"];
         delete?: never;
         options?: never;
@@ -376,7 +376,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Report whether MFA is currently enabled for the user */
+        /** Report whether MFA is currently enabled. Anonymous callers get `enabled: false`. */
         get: operations["getApiV1AuthMfaStatus"];
         put?: never;
         post?: never;
@@ -461,7 +461,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get the current user, active account, memberships, and resolved features */
+        /** Get the current user, active account, memberships, and resolved features. Returns `{ user: null }` for anonymous callers. */
         get: operations["getApiV1UsersMe"];
         put?: never;
         post?: never;
@@ -1825,7 +1825,7 @@ export interface operations {
                                 firstName: string;
                                 lastName: string;
                                 emailVerified: boolean;
-                            };
+                            } | null;
                         };
                         timestamp: string;
                     };
@@ -1838,7 +1838,7 @@ export interface operations {
                                 firstName: string;
                                 lastName: string;
                                 emailVerified: boolean;
-                            };
+                            } | null;
                         };
                         timestamp: string;
                     };
@@ -1851,7 +1851,7 @@ export interface operations {
                                 firstName: string;
                                 lastName: string;
                                 emailVerified: boolean;
-                            };
+                            } | null;
                         };
                         timestamp: string;
                     };
@@ -2447,6 +2447,8 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
+                        user: null;
+                    } | {
                         user: {
                             id: string;
                             email: string;
@@ -2480,6 +2482,8 @@ export interface operations {
                         hasPasswordLogin: boolean;
                     };
                     "multipart/form-data": {
+                        user: null;
+                    } | {
                         user: {
                             id: string;
                             email: string;
@@ -2513,6 +2517,8 @@ export interface operations {
                         hasPasswordLogin: boolean;
                     };
                     "text/plain": {
+                        user: null;
+                    } | {
                         user: {
                             id: string;
                             email: string;


### PR DESCRIPTION
Anonymous probes (/me, /refresh, /mfa/status) used to 401 alongside forged-credential failures — same status code, same red-row-in-devtools, same error-stream noise in GlitchTip and Grafana. The two states are now distinct:

  - missing cookie → 200 with a null-shaped body (anonymous, not a failure)
  - cookie present but invalid → 401 with `invalid_session` (real failure, surfaced to the client as forced-logout)

auth.plugin.ts grows a second guard, `tryAuth`, that the three probe endpoints use; `requireAuth` (renamed from `createAuthMiddleware`) keeps the existing throw-on-missing behavior everywhere else. error-handler downgrades `ApiError(4xx)` from `error` to `warn` so the remaining non-probe 401s stop creating GlitchTip groups for genuine client misbehavior. Tests lock both invariants in: anonymous returns 200, every forged-cookie path still 401s.

Same PR also swaps the transactional email palette from the previous blue accents to BoringStack greens (`#15803d` buttons, `#4ade80` accents) across components/, all 7 content.hbs files, and the preview-index generator.

Docs: new `api/auth-contract` page documenting the two-guard contract with worked examples, telemetry implications, and a "when to reach for tryAuth" rule.

## Summary

<!-- 1–3 bullets. What changed and why. -->

## Test plan

- [ ] `bun run check` (or `bun run check:full` for the cross-app pass) from the repo root
- [ ] Stack smoke if compose/infra touched: `cd infra/compose/compose && ./dev.sh up`

### App merge bars

| Area | Command |
|------|---------|
| API | `cd apps/api && bun run validate` |
| UI | `cd apps/ui && bun run validate` |
| Docs | `cd apps/docs && bun run build:ci` |
| Repo drift | `bun run check` (from repo root) |

## Conventions

- [ ] No `any`, no blind `as`, no `!`
- [ ] New env vars in schema + `.env.example` (+ SECURITY.md when relevant)
- [ ] Tests updated for changed behavior

## Screenshots

<!-- Required for UI changes. -->
