### PR TITLE
fix(stack): align UI refresh with API envelope + prod build config

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -7,6 +7,13 @@ DATABASE_SSL_REJECT_UNAUTHORIZED=true
 # Optional PEM CA bundle for production Postgres TLS verification.
 DATABASE_SSL_CA=
 JWT_SECRET=change-me-to-a-long-random-secret-at-least-32-chars
+# AES-256-GCM key for MFA TOTP secret storage. REQUIRED in production —
+# boot aborts if empty when NODE_ENV=production. Generate with:
+#   openssl rand -base64 32
+# Rotating this key invalidates every existing MFA enrollment, so treat
+# it like a database master key: pick once, store in your secret manager,
+# never edit in place.
+MFA_ENCRYPTION_KEY=
 
 # Public-facing identity + CORS.
 APP_NAME=API Template

--- a/apps/ui/Dockerfile.prod
+++ b/apps/ui/Dockerfile.prod
@@ -11,11 +11,28 @@ COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 
 # Vite bakes import.meta.env.VITE_* into the bundle at build time. Compose
-# passes the API URL via build.args; an empty default keeps `docker build .`
-# (no args) working for local prod smoke tests behind a same-origin reverse
-# proxy. Override per environment via --build-arg VITE_API_URL=...
+# passes these via build.args; empty defaults keep `docker build .` (no args)
+# working for local prod smoke tests behind a same-origin reverse proxy.
+#
+# Every VITE_* the SPA reads at runtime needs a build arg here — if a value
+# isn't piped through at `bun run build` time it falls back to the Zod
+# schema default (typically `http://localhost:7331` for VITE_PUBLIC_URL,
+# empty for the optional fields). A localhost default leaks into Stripe
+# return URLs and gets rejected by `assertAllowedBillingRedirectUrl`.
 ARG VITE_API_URL=""
 ENV VITE_API_URL=$VITE_API_URL
+
+ARG VITE_APP_NAME="BoringStack"
+ENV VITE_APP_NAME=$VITE_APP_NAME
+
+ARG VITE_PUBLIC_URL=""
+ENV VITE_PUBLIC_URL=$VITE_PUBLIC_URL
+
+ARG VITE_SENTRY_DSN=""
+ENV VITE_SENTRY_DSN=$VITE_SENTRY_DSN
+
+ARG VITE_VAPID_PUBLIC_KEY=""
+ENV VITE_VAPID_PUBLIC_KEY=$VITE_VAPID_PUBLIC_KEY
 
 COPY . .
 RUN bun run build

--- a/apps/ui/src/lib/api/openapi.test.ts
+++ b/apps/ui/src/lib/api/openapi.test.ts
@@ -91,8 +91,20 @@ describe("tokenRefresh middleware", () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse(401, { message: "expired" })) // original
       .mockResolvedValueOnce(
-        jsonResponse(200, { accessToken: "fresh-jwt", expiresAt: 9_999 })
-      ) // refresh (must carry a non-null accessToken to count as success)
+        jsonResponse(200, {
+          success: true,
+          data: {
+            user: {
+              id: "u1",
+              email: "u@example.com",
+              firstName: "U",
+              lastName: "Ser",
+              emailVerified: true
+            }
+          },
+          timestamp: "2026-06-01T00:00:00.000Z"
+        })
+      ) // refresh — real session refresh returns the user envelope
       .mockResolvedValueOnce(jsonResponse(200, { id: "u1" })); // retry
     const client = await importClient();
 
@@ -114,16 +126,22 @@ describe("tokenRefresh middleware", () => {
     );
   });
 
-  it("does not retry when refresh responds 200 with { accessToken: null } (anonymous probe)", async () => {
+  it("does not retry when refresh responds 200 with { data: { user: null } } (anonymous probe)", async () => {
     /*
-     * `/auth/refresh` returns 200 + `{ accessToken: null }` for callers
-     * without a refresh cookie. The middleware must read the body and
-     * gate retry on a non-null token; relying on `response.ok` alone
-     * would loop indefinitely after logout.
+     * `/auth/refresh` returns 200 + `{ data: { user: null } }` for callers
+     * without a refresh cookie. The middleware must read the body and gate
+     * retry on a non-null user id; relying on `response.ok` alone would loop
+     * indefinitely after logout.
      */
     fetchMock
       .mockResolvedValueOnce(jsonResponse(401, { message: "expired" })) // original
-      .mockResolvedValueOnce(jsonResponse(200, { accessToken: null })); // anon refresh
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          success: true,
+          data: { user: null },
+          timestamp: "2026-06-01T00:00:00.000Z"
+        })
+      ); // anon refresh
     const client = await importClient();
 
     await expect(
@@ -201,7 +219,19 @@ describe("tokenRefresh middleware", () => {
       .mockResolvedValueOnce(jsonResponse(401, { message: "expired" }))
       // One refresh call:
       .mockResolvedValueOnce(
-        jsonResponse(200, { accessToken: "fresh-jwt", expiresAt: 9_999 })
+        jsonResponse(200, {
+          success: true,
+          data: {
+            user: {
+              id: "u1",
+              email: "u@example.com",
+              firstName: "U",
+              lastName: "Ser",
+              emailVerified: true
+            }
+          },
+          timestamp: "2026-06-01T00:00:00.000Z"
+        })
       )
       // Two retries:
       .mockResolvedValueOnce(jsonResponse(200, { id: "a" }))

--- a/apps/ui/src/lib/api/openapi.ts
+++ b/apps/ui/src/lib/api/openapi.ts
@@ -32,25 +32,23 @@ const BASE_URL = env.VITE_API_URL.replace(/\/$/, "");
 let inFlightRefresh: Promise<boolean> | null = null;
 
 /*
- * `/auth/refresh` returns 200 with `{ accessToken: null }` for anonymous
- * callers (no refresh cookie present) and 200 + `{ accessToken: <jwt> }`
- * on successful refresh. A non-null accessToken is the discriminator
- * between the two; `response.ok` alone treats both as success and the
- * SSE reconnect loop retries indefinitely after logout.
+ * `/auth/refresh` returns 200 with `{ success, data: { user: User | null },
+ * timestamp }`. The auth cookie is rotated server-side via httpOnly Set-Cookie;
+ * the body itself never carries a token. `data.user !== null` is the
+ * discriminator between a real refresh and an anonymous probe (no refresh
+ * cookie present). Treating `response.ok` alone as success retries the SSE
+ * reconnect loop indefinitely after logout because the anonymous probe is
+ * also a 200.
  */
-async function readAccessToken(response: Response): Promise<string | null> {
+async function readSessionUserId(response: Response): Promise<string | null> {
   try {
     const body = (await response.clone().json()) as {
-      accessToken?: string | null;
+      data?: { user?: { id?: unknown } | null } | null;
     } | null;
+    const userId = body?.data?.user?.id;
 
-    if (
-      body !== null &&
-      typeof body === "object" &&
-      typeof body.accessToken === "string" &&
-      body.accessToken.length > 0
-    ) {
-      return body.accessToken;
+    if (typeof userId === "string" && userId.length > 0) {
+      return userId;
     }
 
     return null;
@@ -73,8 +71,8 @@ export async function performRefresh(): Promise<boolean> {
         return false;
       }
 
-      const accessToken = await readAccessToken(response);
-      const success = accessToken !== null;
+      const userId = await readSessionUserId(response);
+      const success = userId !== null;
 
       logger.info({ event: "auth.refresh_attempt", success });
 

--- a/apps/ui/src/lib/env/env.loader.ts
+++ b/apps/ui/src/lib/env/env.loader.ts
@@ -3,16 +3,30 @@ import { z } from "zod";
 import type { IEnv } from "./env.types";
 import { envSchema } from "./schema";
 
+/*
+ * Docker build args bake VITE_* values into the bundle. When a build arg is
+ * omitted the ARG default in `Dockerfile.prod` is the empty string, which
+ * `import.meta.env.VITE_*` faithfully surfaces as `""`. For schemas that
+ * require a non-empty URL (`VITE_PUBLIC_URL`) this would fail validation
+ * instead of falling back to the schema default. Treat empty as "not set"
+ * for fields where empty is not a sentinel.
+ *
+ * `VITE_API_URL` keeps `""` as the same-origin sentinel and goes through
+ * unchanged.
+ */
+const emptyToUndefined = (value: unknown): unknown =>
+  value === "" ? undefined : value;
+
 export function loadEnv(): IEnv {
   const raw = import.meta.env;
   const parsed = envSchema.safeParse({
-    VITE_APP_NAME: raw.VITE_APP_NAME,
+    VITE_APP_NAME: emptyToUndefined(raw.VITE_APP_NAME),
     VITE_API_URL: raw.VITE_API_URL,
-    VITE_PUBLIC_URL: raw.VITE_PUBLIC_URL,
+    VITE_PUBLIC_URL: emptyToUndefined(raw.VITE_PUBLIC_URL),
     VITE_SENTRY_DSN: raw.VITE_SENTRY_DSN,
-    VITE_AUTH_NAMESPACE: raw.VITE_AUTH_NAMESPACE,
+    VITE_AUTH_NAMESPACE: emptyToUndefined(raw.VITE_AUTH_NAMESPACE),
     VITE_VAPID_PUBLIC_KEY: raw.VITE_VAPID_PUBLIC_KEY,
-    VITE_LOCALES: raw.VITE_LOCALES,
+    VITE_LOCALES: emptyToUndefined(raw.VITE_LOCALES),
     MODE: raw.MODE,
     DEV: raw.DEV,
     PROD: raw.PROD

--- a/infra/compose/compose/.env.example
+++ b/infra/compose/compose/.env.example
@@ -25,9 +25,11 @@ ACME_EMAIL=you@example.com
 
 # Required in prod (STACK=prod). Compose fails boot with a clear error if
 # any are unset. Generate JWT_SECRET with `openssl rand -base64 48`.
+# Generate MFA_ENCRYPTION_KEY with `openssl rand -base64 32`.
 # JWT_SECRET=
+# MFA_ENCRYPTION_KEY=
 # FRONTEND_URL=https://example.com
-# PUBLIC_API_URL=https://example.com/api
+# PUBLIC_API_URL=https://example.com         # origin only — the SPA appends /api/v1 itself
 # ALLOWED_ORIGINS=   # leave empty for same-origin; set if exposing api cross-origin
 
 # GHCR image source. Defaults point at the canonical upstream images. If you
@@ -49,10 +51,11 @@ ACME_EMAIL=you@example.com
 # API_IMAGE=ghcr.io/me/my-saas-api:0.3.0
 # UI_IMAGE=ghcr.io/me/my-saas-ui:0.5.1
 
-# Optional: explicit full API URL baked into the SPA prod build. Leave unset
-# for same-origin (the SPA uses relative `/api/*`). Override only if you
-# deploy the API on a different host (cross-origin) and also set
-# ALLOWED_ORIGINS in api.prod.env.
+# Optional: explicit origin baked into the SPA prod build. Leave unset for
+# same-origin (the SPA uses relative `/api/*`). Override only if you deploy
+# the API on a different host (cross-origin) and also set ALLOWED_ORIGINS
+# in api.prod.env. ORIGIN ONLY — no path suffix. The SPA appends `/api/v1`
+# itself, so `https://example.com/api` would produce `/api/api/v1/...`.
 # PUBLIC_API_URL=https://api.example.com
 
 # --- Observability (Grafana + Prometheus + Loki + Tempo) ----------------

--- a/infra/compose/compose/docker-compose.yml
+++ b/infra/compose/compose/docker-compose.yml
@@ -407,6 +407,14 @@ services:
         condition: service_started
       api-migrate-prod:
         condition: service_completed_successfully
+    # Readiness, not liveness. The api starts listening before
+    # `setupQueues()` resolves (see apps/api/src/index.ts) so `/health`
+    # can flip green while BullMQ is still warming up — ui then boots
+    # through `condition: service_healthy` and the first queue-backed
+    # request 503s. `/ready` aggregates db + valkey + queue + email
+    # checks and returns 503 until everything in the startup path is
+    # `ok` or `degraded`. The api-dev profile keeps `/health` because
+    # dev tolerates degraded optional features (e.g. noop email).
     healthcheck:
       test:
         [
@@ -415,7 +423,7 @@ services:
           "--no-verbose",
           "--tries=1",
           "--spider",
-          "http://localhost:7330/health",
+          "http://localhost:7330/ready",
         ]
       interval: 5s
       timeout: 3s
@@ -464,7 +472,14 @@ services:
       context: ../../../apps/ui
       dockerfile: Dockerfile.prod
       args:
+        # Origin only — see compose/.env.example. The SPA appends /api/v1.
         VITE_API_URL: ${PUBLIC_API_URL:-}
+        # Used by Stripe checkout return URLs + share links. Must equal the
+        # API's FRONTEND_URL or `assertAllowedBillingRedirectUrl` rejects it.
+        VITE_PUBLIC_URL: ${FRONTEND_URL:-}
+        VITE_APP_NAME: ${VITE_APP_NAME:-BoringStack}
+        VITE_SENTRY_DSN: ${VITE_SENTRY_DSN:-}
+        VITE_VAPID_PUBLIC_KEY: ${VITE_VAPID_PUBLIC_KEY:-}
     labels:
       - "wud.watch=true"
       - "wud.trigger.include=docker.app,discord.1,slack.alerts"


### PR DESCRIPTION
## Summary
Codex audit follow-up — five gaps that survived the PR #73 sweep, found while cross-checking the refresh contract and the production Docker build pipeline.

## What changed

- **UI refresh contract.** `performRefresh()` was looking for a top-level `accessToken` field that the API never returned (the auth cookie is rotated via `Set-Cookie`; the body is `{ success, data: { user }, timestamp }`). Result: every access-token expiry surfaced as a forced logout because the UI returned `false` from a successful refresh. Now reads `data.user.id` and treats a non-null user as success. Test mocks rebuilt against the OpenAPI schema.
- **`PUBLIC_API_URL` footgun.** `compose/.env.example:30` documented `PUBLIC_API_URL=https://example.com/api`, but the UI appends `/api/v1` itself in three places (`openapi.ts`, `oauth.service.ts`, `Notifications.stream-utils.ts`), producing `/api/api/v1/...` URLs in prod. Both example sites now state ORIGIN ONLY.
- **`Dockerfile.prod` missing build args.** Only `VITE_API_URL` was wired. `VITE_PUBLIC_URL` defaulted to `http://localhost:7331` and got baked into the prod bundle → Stripe checkout return URLs failed `assertAllowedBillingRedirectUrl`. `VITE_SENTRY_DSN`, `VITE_VAPID_PUBLIC_KEY`, and `VITE_APP_NAME` similarly silently degraded. All four wired through compose, with `VITE_PUBLIC_URL: ${FRONTEND_URL:-}` so SPA and API agree on origin without a second var.
- **Env loader empty-string handling.** Empty-string build args (the default when compose passes through an unset var) now coerce to `undefined` for fields where empty isn't a sentinel, so Zod's schema defaults apply instead of failing `.url()` validation at runtime. `VITE_API_URL` keeps `""` as the same-origin sentinel and goes through unchanged.
- **Prod compose healthcheck.** The api service now probes `/ready` instead of `/health`. The api starts listening before `setupQueues()` resolves (`apps/api/src/index.ts:37` vs `:49`), so `/health` could flip green while BullMQ was still warming up — the ui service then booted via `condition: service_healthy` and the first queue-backed request 503ed. `/ready` aggregates db + valkey + queue + email and returns 503 until every startup-critical dep is `ok` or `degraded`. api-dev keeps `/health` because dev tolerates degraded optional features (noop email, etc.).
- **`MFA_ENCRYPTION_KEY` visibility.** Surfaced next to `JWT_SECRET` in `apps/api/.env.example` with a rotation note; compose `.env.example` required block also lists it. Production boot already fails-fast on empty via the boot invariants module from #73 — a first-time deployer should see the var in the env example, not discover it at boot.

## Skipped (with rationale)
- **P2 (Origin/Referer + CSRF token middleware)** — already addressed in PR #73 as the documented SameSite-only stance + `apps/docs/.../csrf-stance.mdx`. No change needed unless we adopt a cross-site deployment topology.
- **P3 (UI/API authorization rule duplication)** — real but out of scope; would need a generated rule-matrix codegen or parity test, neither of which fits a follow-up.

## Test plan
- [x] `bun run check` (lint + lint-meta + format + typecheck + knip) — clean on apps/api and apps/ui
- [x] API tests: 1031 pass / 2 skip / 0 fail (the 2 skipped need local Postgres)
- [x] UI tests: 534 / 534 pass
- [x] `openapi.test.ts` — refresh middleware tests rewritten against the real envelope, all 11 pass
- [ ] Manual: register a user, let the JWT TTL expire, confirm the next API call silently refreshes instead of bouncing to `/login`
- [ ] Manual: `STACK=prod ./dev.sh up -d --build` with `PUBLIC_API_URL=https://example.com` (no `/api` suffix) → `/api/v1/users/me` resolves cleanly
- [ ] Manual: prod build with `FRONTEND_URL=https://example.com` → Stripe checkout return URL passes `assertAllowedBillingRedirectUrl`