### PR TITLE
Chore/audit fixes 20260601 1540

### DIFF
--- a/.claude/skills/audit-monorepo.md
+++ b/.claude/skills/audit-monorepo.md
@@ -26,6 +26,17 @@ The output is a single JSON file. No essays, no praise, no generic advice.
 5. **Rank for an autonomous agent**, not a human reviewer: order `execution_plan` by
    what a coding agent should safely execute first (low blast radius, unblocks others,
    verifiable).
+6. **Guardrail-first mindset (lint as a contract).** This stack prevents defects with
+   linters and parsers, not review. For every finding, decide whether it is a _class_ a
+   static check could catch and fill `guardrail` (which layer, which rule to add/extend).
+   If a guardrail already _claims_ the class but the finding slipped through, that gap IS
+   part of the finding — say so in `guardrail.note`. The executor adds the rule before
+   fixing, so your job is to point it at the right layer. The two layers:
+   - **lint-meta** (in-repo, editable: `apps/<app>/scripts/lint-meta/rules/<category>/`) —
+     repo-level drift: version/SHA pins, CI parity, env cascade, source-text bans,
+     test-sibling coverage, config.
+   - **eslint-plugin** (`@boring-stack-pkg/eslint-plugin-*`, cross-repo) — architecture
+     _inside_ TypeScript modules. Note it, but it can't be edited from this repo.
 
 ## Process
 
@@ -55,8 +66,10 @@ Agent call per cell). Recommended decomposition (~8 cells; adjust to repo size):
 
 Give each subagent: its scope paths, its dimensions, the **finding object schema
 below**, and these orders verbatim: *read-only; cite exact file + line/symbol for every
-finding; return a JSON array of finding objects ONLY (no prose); if evidence is weak,
-return it under a `blocked` array instead; prefer precise over vague.*
+finding; for each finding set `guardrail` — could a lint-meta rule or ESLint plugin
+enforce this class of defect? name the rule to add or extend, or set `enforceable:false`
+for genuine one-offs; return a JSON array of finding objects ONLY (no prose); if evidence
+is weak, return it under a `blocked` array instead; prefer precise over vague.*
 
 ### 3. Merge + rank (orchestrator)
 - Collect all subagent arrays. Dedupe overlapping findings (same file+symbol).
@@ -66,6 +79,8 @@ return it under a `blocked` array instead; prefer precise over vague.*
   `cd apps/ui && bun run check` / `bun run test:ci`, `cd apps/docs && bun run build:ci`,
   or a targeted `grep`/file assertion. Never invent commands.
 - Build `execution_plan` ordered for an autonomous agent (safe-first, unblock-first).
+  Treat `guardrail.enforceable` findings as higher-leverage at equal severity — fixing
+  one closes a whole class, not one instance.
 - `quick_wins` = finding IDs with `effort: "S"` and severity ≥ medium.
 - Anything weak/unverifiable → `blocked_or_uncertain`.
 
@@ -99,7 +114,13 @@ Print to chat ONLY: the path and counts, e.g.
       "impact": "",
       "fix": "",
       "execution_steps": [],
-      "validation": ""
+      "validation": "",
+      "guardrail": {
+        "enforceable": true,
+        "layer": "lint-meta|eslint-plugin|none",
+        "rule": "<existing rule to extend, or proposed new rule name>",
+        "note": "why this class can (or cannot) be a static check"
+      }
     }
   ],
   "execution_plan": [
@@ -136,6 +157,8 @@ Do NOT report: style the formatter/ESLint already enforces, anything without a f
 or "consider adding X" advice with no concrete defect.
 
 ## Red flags — you are doing it wrong if
+- A finding is a class a linter/parser could catch but you left `guardrail.enforceable`
+  unset or didn't name the rule to add/extend.
 - You wrote prose explanation in chat instead of the JSON file.
 - A finding has no `file`. (→ `blocked_or_uncertain`.)
 - You ran the audit single-threaded when the repo is large. (→ fan out.)

--- a/.claude/skills/execute-audit.md
+++ b/.claude/skills/execute-audit.md
@@ -19,6 +19,41 @@ genericness (works for any consumer of the template, no app-specific assumptions
 developer experience**. Never pick the lazy option; pick the one a senior engineer
 shipping a flagship template would. Record the choice in the run log.
 
+## Guardrail-first remediation (lint as a contract)
+
+This stack's core value is **lint as a contract**: defects are _prevented by linters and
+parsers_, not caught by review. So before fixing a finding, ask: **is this a _class_ of
+defect a static check could catch — not a one-off logic bug?** If yes, the fix is not the
+code change alone; it is **the guardrail plus the code change**, in this order:
+
+1. **Find or create the rule.** Two layers:
+   - **lint-meta** (in-repo; repo-level drift: version/SHA pins, CI parity, env cascade,
+     source-text bans, test-sibling coverage, config). Add or extend an `IMetaRule` under
+     `apps/<app>/scripts/lint-meta/rules/<category>/` and register it in `registry.ts`.
+     This is the default — it lives in this repo and you can edit it.
+   - **ESLint custom plugins** (`@boring-stack-pkg/eslint-plugin-*`; architecture _inside_
+     TypeScript modules). Source is cross-repo (`boringstack-xyz/eslint-plugins`) and
+     usually not editable from here — if the class fits, express it as a lint-meta
+     source-text rule instead; otherwise flag it for that repo in the run log.
+2. **Surface the bug through the rule (RED).** Run `bun run lint:meta` (or `bun run check`)
+   and confirm the finding's exact instances now fail as violations. If the rule doesn't
+   flag them, the rule is wrong — fix the rule first. A guardrail that misses the known
+   case is worthless.
+3. **Fix the code until the rule passes (GREEN).** The command that surfaced the bug now
+   proves it's gone.
+4. **Lock it in.** Add/extend a test under `apps/<app>/tests/lint-meta/`, run
+   `bun run generate:lint-meta-docs` to refresh `RULES.md`, and commit rule + test + fix
+   together. The rule now blocks this defect for every future consumer of the template.
+
+**An existing rule with a gap still counts.** If a finding is a class a guardrail _claims_
+to cover but slipped through (e.g. actions that should be SHA-pinned with no rule enforcing
+it, or a rule that misses a syntax variant), the real bug is the gap: close the rule, watch
+the instances surface, then fix.
+
+**When NOT to add a rule:** genuinely one-off logic bugs, data-specific issues, or anything
+not expressible as a static check — fix those directly. When unsure, lean toward the rule;
+extending the tooling is the higher-leverage outcome for this stack.
+
 ## Completion discipline
 
 Finish every finding. Do not stop early, do not batch-ask for confirmation, do not
@@ -53,14 +88,17 @@ disjoint in files.
 
 ### 4. Per finding (the loop)
 1. Mark the todo in_progress.
-2. Apply the fix using the finding's `fix` + `execution_steps`. Honor the repo merge
-   bar from `apps/api/AGENT_CONTRACT.md` (no `any`/`as`/`!`, no inline `eslint-disable`,
-   `ApiErrors.*` not `new Error`, structured logging with `event:`, etc.). For
-   judgment calls, apply the **North star**.
-3. Validate: run the finding's `validation` command, AND the fast Docker-free gate in
-   every app you touched — `cd apps/api && bun run check`, `cd apps/ui && bun run check`,
-   `cd apps/docs && bun run check:docs-data` (docs has no `check` script until F005 adds
-   one). Heavy `validate`/tests/e2e run at push time via the pre-push hook.
+2. **Classify, then fix.** Apply **Guardrail-first remediation** (above): if the finding is
+   a class a linter/parser can enforce, add or extend the rule, surface the bug through it,
+   then fix the code. Otherwise apply the fix directly from `fix` + `execution_steps`.
+   Either way honor the repo merge bar from `apps/api/AGENT_CONTRACT.md` (no `any`/`as`/`!`,
+   no inline `eslint-disable`, `ApiErrors.*` not `new Error`, structured logging with
+   `event:`). For judgment calls, apply the **North star**.
+3. Validate: run the finding's `validation` command (plus `bun run lint:meta` for any rule
+   you added/extended), AND the fast Docker-free gate in every app you touched —
+   `cd apps/api && bun run check`, `cd apps/ui && bun run check`,
+   `cd apps/docs && bun run check:docs-data` (docs has no `check` script). Heavy
+   `validate`/tests/e2e run at push time via the pre-push hook.
 4. **Green** → commit just this finding's files with a conventional message, e.g.
    `fix(<scope>): <finding title>` and a trailer `Audit: <finding id>`. Mark todo done.
    **Red** → make up to 2 repair attempts. Still red → `git restore`/`git checkout --`
@@ -89,6 +127,9 @@ disjoint in files.
 | push (full gate) | `git push -u origin <branch>` |
 
 ## Red flags — you are doing it wrong if
+- You patched a class-of-defect finding with a one-off code change when a lint-meta rule
+  could enforce it — extend the guardrail first, then fix (lint as a contract).
+- You wrote a rule that doesn't actually flag the finding's known instances.
 - You asked the user to confirm mid-run instead of deciding via the North star.
 - You committed code that fails `bun run check`.
 - You stopped after the `execution_plan` items and ignored the rest of `findings[]`.

--- a/.github/workflows/apps-docs-linkcheck.yml
+++ b/.github/workflows/apps-docs-linkcheck.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: apps/docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Detect docs changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -58,7 +58,7 @@ jobs:
         if: steps.filter.outputs.docs != 'true'
         run: echo "No docs files changed in this PR — link check skipped."
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         if: steps.filter.outputs.docs == 'true'
         with:
           bun-version: 1.3.14
@@ -93,7 +93,7 @@ jobs:
 
       - name: Internal link check (fail on broken)
         if: steps.filter.outputs.docs == 'true'
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: >-
             --no-progress
@@ -104,7 +104,7 @@ jobs:
 
       - name: External link check (warning only)
         if: steps.filter.outputs.docs == 'true'
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         continue-on-error: true
         with:
           args: >-

--- a/.github/workflows/infra-bootstrap-validate.yml
+++ b/.github/workflows/infra-bootstrap-validate.yml
@@ -21,7 +21,7 @@ jobs:
         working-directory: infra/bootstrap
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Detect relevant changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install OpenTofu
         if: steps.filter.outputs.code == 'true'
-        uses: opentofu/setup-opentofu@v2
+        uses: opentofu/setup-opentofu@847eaa4afeb791b06daa46e8eafa8b1b68d7cfb4 # v2.0.1
         with:
           tofu_wrapper: false
 

--- a/.github/workflows/infra-compose-full-stack-smoke.yml
+++ b/.github/workflows/infra-compose-full-stack-smoke.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout monorepo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Detect relevant changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2

--- a/.github/workflows/infra-compose-playwright-e2e.yml
+++ b/.github/workflows/infra-compose-playwright-e2e.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout monorepo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Seed compose/.env
         working-directory: infra/compose/compose

--- a/.github/workflows/infra-compose-security-secrets.yml
+++ b/.github/workflows/infra-compose-security-secrets.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
+        uses: github/codeql-action/upload-sarif@7c1e4cf0b20d7c1872b26569c00ba908797a59bf # v4
         with:
           sarif_file: gitleaks-results.sarif
           category: gitleaks

--- a/.github/workflows/infra-compose-validate-compose.yml
+++ b/.github/workflows/infra-compose-validate-compose.yml
@@ -184,9 +184,11 @@ jobs:
           filters: |
             code:
               - 'apps/api/Dockerfile.prod'
+              - 'apps/api/.dockerignore'
               - 'apps/api/package.json'
               - 'apps/api/bun.lock'
               - 'apps/ui/Dockerfile.prod'
+              - 'apps/ui/.dockerignore'
               - 'apps/ui/package.json'
               - 'apps/ui/bun.lock'
               - 'infra/compose/**'

--- a/.github/workflows/infra-compose-validate-compose.yml
+++ b/.github/workflows/infra-compose-validate-compose.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Detect relevant changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -146,7 +146,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Detect relevant changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -175,7 +175,7 @@ jobs:
     # the post-merge release workflow.
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Detect relevant changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -228,7 +228,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Detect relevant changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -6,6 +6,8 @@ DATABASE_URL=postgresql://app:app_dev_password@localhost:5432/app
 DATABASE_SSL_REJECT_UNAUTHORIZED=true
 # Optional PEM CA bundle for production Postgres TLS verification.
 DATABASE_SSL_CA=
+# Postgres connection pool size, per API instance. Default 10.
+# DATABASE_POOL_SIZE=10
 JWT_SECRET=change-me-to-a-long-random-secret-at-least-32-chars
 # AES-256-GCM key for MFA TOTP secret storage. REQUIRED in production —
 # boot aborts if empty when NODE_ENV=production. Generate with:
@@ -75,6 +77,15 @@ SENTRY_DSN=
 # the request path (Sentry's Bun SDK is built on @sentry/opentelemetry).
 SENTRY_TRACES_SAMPLE_RATE=0
 
+# --- Tracing — OpenTelemetry → Tempo ------------------------------------
+# When OTEL_EXPORTER_OTLP_ENDPOINT is set, the API ships spans via OTLP/HTTP
+# to that endpoint (Tempo, bundled in the compose stack). Empty = the OTel
+# SDK is not initialized. In compose this is wired automatically; set it here
+# only for bare-bun local tracing. OTEL_SERVICE_NAME is the `service.name`
+# Grafana groups spans by in Tempo's Explore tab.
+# OTEL_EXPORTER_OTLP_ENDPOINT=
+OTEL_SERVICE_NAME=boringstack-api
+
 # Email — pick one provider; only that provider's keys are required.
 # Default: Cloudflare Email Service (https://developers.cloudflare.com/email-service/).
 # Setup walkthrough: infra/compose/docs/runbooks/cloudflare-email.md
@@ -94,9 +105,15 @@ CLOUDFLARE_EMAIL_API_TOKEN=            # API token with "Email Sending: Edit"
 
 # --- resend (alternate) ------------------------------------------------
 # RESEND_API_KEY=
+# whsec_… signing secret for the bounce/complaint webhook at
+# /api/v1/webhooks/resend. Empty disables the route (503).
+# RESEND_WEBHOOK_SECRET=
 
 # --- sendgrid (alternate) ----------------------------------------------
 # SENDGRID_API_KEY=
+# PEM-encoded ECDSA P-256 public key from SendGrid's Signed Event Webhook.
+# Required for the bounce/complaint webhook at /api/v1/webhooks/sendgrid.
+# SENDGRID_WEBHOOK_PUBLIC_KEY=
 
 # --- smtp (Mailpit / Postfix / etc.) -----------------------------------
 # Use SMTP_HOST=mailpit + SMTP_PORT=1025 to point at the local catcher

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,6 +8,7 @@
   "engines": {
     "bun": "1.3.14"
   },
+  "packageManager": "bun@1.3.14",
   "scripts": {
     "test": "bun run build:templates && NODE_ENV=test bun run scripts/quality/run-tests-clean.ts",
     "test:coverage": "bun run build:templates && NODE_ENV=test bun run scripts/quality/check-coverage.ts",

--- a/apps/api/src/templates/email/preview.ts
+++ b/apps/api/src/templates/email/preview.ts
@@ -424,6 +424,11 @@ const main = (): void => {
   generateIndex(previews);
   console.log(`✓ Generated ${String(previews.length)} preview page(s)`);
 
+  /*
+   * PREVIEW_PORT: dev-only override for this template-preview server's port
+   * (defaults to 3002). Read directly rather than via the validated env schema
+   * because it never runs in the deployed app — only `bun run preview:templates`.
+   */
   const portEnv = process.env.PREVIEW_PORT;
   const port =
     portEnv !== undefined && portEnv !== "" ? parseInt(portEnv, 10) : 3002;

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -46,6 +46,13 @@
     "starlight-llms-txt": "0.6.1",
     "wrangler": "4.93.0"
   },
+  "//overrides": {
+    "_": "Why these transitive deps are pinned. Build-time/dev tooling only — the deployed site is static Cloudflare Pages. Re-evaluate quarterly (see osv-scanner.toml).",
+    "ws": "Pin patched ws (GHSA-58qx-3vcg-4xpx) pulled via miniflare/wrangler dev tooling.",
+    "devalue": "Pin patched devalue build-time serialization XSS (GHSA-77vg-94rm-hx3p).",
+    "qs": "Pin patched qs (GHSA-q8mj-m7cp-5q26) pulled via the http-server dev preview tool.",
+    "tmp": "Pin patched tmp symlink arbitrary-write advisory; transitive dev-tooling dep."
+  },
   "overrides": {
     "ws": "8.20.1",
     "devalue": "5.8.1",

--- a/apps/docs/src/components/docs-kit/LintMetaCatalog.tsx
+++ b/apps/docs/src/components/docs-kit/LintMetaCatalog.tsx
@@ -13,7 +13,14 @@ interface RuleRow {
 }
 
 export default function LintMetaCatalog({ template }: LintMetaCatalogProps) {
-  const rules = (lintMetaCatalog[template] ?? []) as RuleRow[];
+  const rules = lintMetaCatalog[template] as RuleRow[] | undefined;
+
+  if (rules === undefined) {
+    throw new Error(
+      `LintMetaCatalog: no entry for template "${template}" in lint-meta-catalog.json — regenerate with \`bun run generate:lint-meta-docs\`.`,
+    );
+  }
+
   const categories = [...new Set(rules.map((rule) => rule.category))];
 
   return (

--- a/apps/docs/src/components/docs-kit/ScriptsCatalog.tsx
+++ b/apps/docs/src/components/docs-kit/ScriptsCatalog.tsx
@@ -33,7 +33,13 @@ interface TemplateCatalog {
 }
 
 export default function ScriptsCatalog({ template }: ScriptsCatalogProps) {
-  const catalog = scriptsCatalog[template] as TemplateCatalog;
+  const catalog = scriptsCatalog[template] as TemplateCatalog | undefined;
+
+  if (catalog === undefined) {
+    throw new Error(
+      `ScriptsCatalog: no entry for template "${template}" in scripts-catalog.json — regenerate with \`bun run generate:scripts-docs\`.`,
+    );
+  }
 
   return (
     <div className="not-content space-y-8">

--- a/apps/docs/src/content/docs/architecture/lint-meta.mdx
+++ b/apps/docs/src/content/docs/architecture/lint-meta.mdx
@@ -4,6 +4,7 @@ description: Static repo enforcement rules that run alongside ESLint, package.js
 ---
 
 import { Aside } from "@astrojs/starlight/components";
+import LintMetaCatalog from "../../../components/docs-kit/LintMetaCatalog";
 
 ESLint enforces architecture inside TypeScript modules. `lint:meta` catches repo-level drift ESLint cannot see: unpinned GitHub Actions, env cascade gaps, forbidden inline disables, cross-repo imports, and missing test siblings. It runs inside `bun run validate`.
 
@@ -15,30 +16,19 @@ typecheck → ESLint → lint:meta → knip → tests
 
 <Aside type="tip" title="Machine-readable source">
   Each template registers rules in <code>scripts/lint-meta/registry.ts</code>.
-  This page is generated from that registry, add a rule, run the generator,
-  and CI keeps the docs aligned.
+  This page is generated from that registry, add a rule, run the generator, and
+  CI keeps the docs aligned.
 </Aside>
 
-## UI-only rules
+## apps/ui rules
 
-The apps/ui catalog includes rules that only apply to the SPA repo:
+<LintMetaCatalog template="ui" />
 
-- `no-cross-repo-import`, **CI-critical**; UI imports must not reach into backend or infra source
-- `modulepreload-size-limit-coverage`, bundle size-limit config must cover modulepreload chunks
-- `no-dark-variant`, `no-dangerous-html`, `env-access`, `no-raw-fetch`, source-text bans for Vite/React patterns
+## apps/api rules
 
-## API-only rules
+<LintMetaCatalog template="api" />
 
-The apps/api catalog adds backend test contracts:
-
-- `routes-require-test-sibling`, every `*.routes.ts` needs a matching `tests/api/**/*.routes.test.ts`
-- `touch-tests-too`, opt-in via `LINT_META_TOUCHED_BASE` for diff-aware test enforcement
-
-## Shared rules
-
-Both templates share supply-chain, CI, env, artifact, and config rules (exact deps, pre-push CI parity, engine pin parity, generated artifact banners, forbidden inline disables, raw role literals, logic-file test siblings).
-
-See the ESLint plugin inventory and implementation under `scripts/lint-meta/` in the boringstack repo.
+Implementation lives under `scripts/lint-meta/` in each template.
 
 ## Adding a rule
 

--- a/apps/docs/src/data/lint-meta-catalog.json
+++ b/apps/docs/src/data/lint-meta-catalog.json
@@ -139,6 +139,12 @@
       "description": "Logic modules must ship with a colocated *.test.ts or *.test.tsx sibling."
     },
     {
+      "id": "skipped-tests-need-tracking",
+      "category": "testing",
+      "ciCritical": false,
+      "description": "Skipped tests (.skip/.only/xit/xdescribe) must carry an issue URL or TODO(@owner) so the debt has a tracked owner."
+    },
+    {
       "id": "eslint-config-no-warn",
       "category": "config",
       "ciCritical": false,
@@ -241,6 +247,12 @@
       "category": "testing",
       "ciCritical": false,
       "description": "Logic modules must ship with a matching tests/**/*.test.ts sibling."
+    },
+    {
+      "id": "skipped-tests-need-tracking",
+      "category": "testing",
+      "ciCritical": false,
+      "description": "Skipped tests (.skip/.only/xit/xdescribe) must carry an issue URL or TODO(@owner) so the debt has a tracked owner."
     },
     {
       "id": "touch-tests-too",

--- a/apps/ui/.size-limit.json
+++ b/apps/ui/.size-limit.json
@@ -27,21 +27,117 @@
     "gzip": true
   },
   {
-    "name": "Login page chunk",
+    "name": "CSS (Tailwind compiled)",
+    "path": "dist/assets/*.css",
+    "limit": "12 KB",
+    "gzip": true
+  },
+  {
+    "name": "LoginPage chunk",
     "path": "dist/assets/LoginPage-*.js",
     "limit": "20 KB",
     "gzip": true
   },
   {
-    "name": "Dashboard page chunk",
+    "name": "DashboardPage chunk",
     "path": "dist/assets/DashboardPage-*.js",
     "limit": "5 KB",
     "gzip": true
   },
   {
-    "name": "CSS (Tailwind compiled)",
-    "path": "dist/assets/*.css",
-    "limit": "12 KB",
+    "name": "SettingsPage chunk",
+    "path": "dist/assets/SettingsPage-*.js",
+    "limit": "20 KB",
+    "gzip": true
+  },
+  {
+    "name": "BillingPage chunk",
+    "path": "dist/assets/BillingPage-*.js",
+    "limit": "4 KB",
+    "gzip": true
+  },
+  {
+    "name": "NotificationsPage chunk",
+    "path": "dist/assets/NotificationsPage-*.js",
+    "limit": "4 KB",
+    "gzip": true
+  },
+  {
+    "name": "NotificationsPreferencesPage chunk",
+    "path": "dist/assets/NotificationsPreferencesPage-*.js",
+    "limit": "3 KB",
+    "gzip": true
+  },
+  {
+    "name": "InvitationsPage chunk",
+    "path": "dist/assets/InvitationsPage-*.js",
+    "limit": "4 KB",
+    "gzip": true
+  },
+  {
+    "name": "InvitationAcceptPage chunk",
+    "path": "dist/assets/InvitationAcceptPage-*.js",
+    "limit": "3 KB",
+    "gzip": true
+  },
+  {
+    "name": "OwnershipTransferAcceptPage chunk",
+    "path": "dist/assets/OwnershipTransferAcceptPage-*.js",
+    "limit": "3 KB",
+    "gzip": true
+  },
+  {
+    "name": "JoinRequestsPage chunk",
+    "path": "dist/assets/JoinRequestsPage-*.js",
+    "limit": "3 KB",
+    "gzip": true
+  },
+  {
+    "name": "AuditLogPage chunk",
+    "path": "dist/assets/AuditLogPage-*.js",
+    "limit": "3 KB",
+    "gzip": true
+  },
+  {
+    "name": "ProfilePage chunk",
+    "path": "dist/assets/ProfilePage-*.js",
+    "limit": "3 KB",
+    "gzip": true
+  },
+  {
+    "name": "SignUpPage chunk",
+    "path": "dist/assets/SignUpPage-*.js",
+    "limit": "3 KB",
+    "gzip": true
+  },
+  {
+    "name": "ForgotPasswordPage chunk",
+    "path": "dist/assets/ForgotPasswordPage-*.js",
+    "limit": "3 KB",
+    "gzip": true
+  },
+  {
+    "name": "ResetPasswordPage chunk",
+    "path": "dist/assets/ResetPasswordPage-*.js",
+    "limit": "3 KB",
+    "gzip": true
+  },
+  {
+    "name": "VerifyEmailPage chunk",
+    "path": "dist/assets/VerifyEmailPage-*.js",
+    "limit": "3 KB",
+    "gzip": true
+  },
+  {
+    "name": "OAuthCallbackPage chunk",
+    "path": "dist/assets/OAuthCallbackPage-*.js",
+    "limit": "3 KB",
+    "gzip": true
+  },
+  {
+    "name": "NotFoundPage chunk",
+    "path": "dist/assets/NotFoundPage-*.js",
+    "limit": "2 KB",
     "gzip": true
   }
 ]

--- a/apps/ui/e2e/auth.spec.ts
+++ b/apps/ui/e2e/auth.spec.ts
@@ -20,7 +20,7 @@ test.describe("Auth flow", () => {
   test("shows error toast for bad credentials", async ({ page, login }) => {
     await login.goto();
     await login.loginAs("wrong@example.com", "wrongpassword");
-    await expect(page.getByText(/incorrect/i)).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText(/incorrect/i)).toBeVisible();
   });
 
   test("logs in successfully and lands on dashboard", async ({

--- a/apps/ui/e2e/fixtures/auth.ts
+++ b/apps/ui/e2e/fixtures/auth.ts
@@ -3,6 +3,7 @@ import {
   test as base,
   request
 } from "@playwright/test";
+import { randomUUID } from "node:crypto";
 
 import { DashboardPage } from "../pages/DashboardPage";
 import { LoginPage } from "../pages/LoginPage";
@@ -17,7 +18,7 @@ interface ITestUser {
  *
  *   - `testUser`: a freshly-registered user via the API. Worker-scoped so
  *     every test in a worker shares one account, keeping the suite fast. The
- *     email is randomized per worker so parallel workers + re-runs don't
+ *     email carries a per-worker UUID so parallel workers + re-runs can never
  *     collide on the unique-email index.
  *   - `login` / `dashboard`: page objects on a clean unauthenticated session.
  *   - `authedPage`: a logged-in page that has landed on /dashboard.
@@ -74,7 +75,7 @@ export const test = base.extend<
     async ({}, use, workerInfo) => {
       const baseURL = "http://localhost:7331";
       const user: ITestUser = {
-        email: `e2e-${String(workerInfo.workerIndex)}-${String(Date.now())}-${String(Math.floor(Math.random() * 1_000_000))}@e2e.test`,
+        email: `e2e-${String(workerInfo.workerIndex)}-${randomUUID()}@e2e.test`,
         password: "E2EPassword123!"
       };
 

--- a/apps/ui/e2e/mfa.spec.ts
+++ b/apps/ui/e2e/mfa.spec.ts
@@ -128,11 +128,11 @@ test.describe("MFA login flow", () => {
      */
     const codeInput = page.getByTestId("mfa-login-code");
 
-    await expect(codeInput).toBeVisible({ timeout: 10_000 });
+    await expect(codeInput).toBeVisible();
     await codeInput.fill(generateLiveTotp(mfa.secretBase32));
     await page.getByTestId("mfa-login-submit").click();
 
-    await expect(page).toHaveURL(/\/dashboard/, { timeout: 10_000 });
+    await expect(page).toHaveURL(/\/dashboard/);
   });
 
   test("a recovery code completes the sign-in", async ({ page }) => {
@@ -151,7 +151,7 @@ test.describe("MFA login flow", () => {
 
     const codeInput = page.getByTestId("mfa-login-code");
 
-    await expect(codeInput).toBeVisible({ timeout: 10_000 });
+    await expect(codeInput).toBeVisible();
 
     // Toggle to recovery mode via the link button at the bottom.
     await page
@@ -162,7 +162,7 @@ test.describe("MFA login flow", () => {
     await codeInput.fill(recoveryCode);
     await page.getByTestId("mfa-login-submit").click();
 
-    await expect(page).toHaveURL(/\/dashboard/, { timeout: 10_000 });
+    await expect(page).toHaveURL(/\/dashboard/);
   });
 
   test("an invalid TOTP code keeps the user on the challenge form", async ({
@@ -177,11 +177,11 @@ test.describe("MFA login flow", () => {
 
     const codeInput = page.getByTestId("mfa-login-code");
 
-    await expect(codeInput).toBeVisible({ timeout: 10_000 });
+    await expect(codeInput).toBeVisible();
     await codeInput.fill("000000");
     await page.getByTestId("mfa-login-submit").click();
 
-    await expect(codeInput).toBeVisible({ timeout: 5_000 });
+    await expect(codeInput).toBeVisible();
     await expect(page).not.toHaveURL(/\/dashboard/);
   });
 });

--- a/apps/ui/e2e/signup.spec.ts
+++ b/apps/ui/e2e/signup.spec.ts
@@ -48,7 +48,7 @@ test.describe("Sign-up flow", () => {
     });
     await signup.submit();
 
-    await expect(signup.checkEmailHeading()).toBeVisible({ timeout: 10_000 });
+    await expect(signup.checkEmailHeading()).toBeVisible();
     await expect(page.getByText(uniqueEmail)).toBeVisible();
   });
 

--- a/apps/ui/e2e/verify-email.spec.ts
+++ b/apps/ui/e2e/verify-email.spec.ts
@@ -63,9 +63,7 @@ test.describe("Verify-before-account UX", () => {
        * verified yet." Matching the substring keeps the assertion
        * resilient to copy tweaks.
        */
-      await expect(page.getByText(/email isn't verified/i)).toBeVisible({
-        timeout: 5_000
-      });
+      await expect(page.getByText(/email isn't verified/i)).toBeVisible();
 
       await expect(
         page.getByRole("button", { name: /resend verification email/i })
@@ -79,7 +77,7 @@ test.describe("Verify-before-account UX", () => {
     page
   }) => {
     await page.goto(`${BASE_URL}/verify-email`);
-    await expect(page.getByRole("alert")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByRole("alert")).toBeVisible();
     await expect(page.getByText(/missing its token/i)).toBeVisible();
   });
 
@@ -87,7 +85,7 @@ test.describe("Verify-before-account UX", () => {
     page
   }) => {
     await page.goto(`${BASE_URL}/verify-email?token=${"0".repeat(48)}`);
-    await expect(page.getByRole("alert")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByRole("alert")).toBeVisible();
     await expect(page.getByText(/invalid or expired/i)).toBeVisible();
   });
 });

--- a/apps/ui/playwright.config.ts
+++ b/apps/ui/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     ? [["github"], ["html", { open: "never" }]]
     : [["html", { open: "never" }], ["list"]],
   timeout: 30_000,
-  expect: { timeout: 5_000 },
+  expect: { timeout: 12_000 },
   use: {
     baseURL: BASE_URL,
     trace: "on-first-retry",

--- a/apps/ui/src/app/providers/ErrorBoundaryProvider.test.tsx
+++ b/apps/ui/src/app/providers/ErrorBoundaryProvider.test.tsx
@@ -1,0 +1,47 @@
+import * as Sentry from "@sentry/react";
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ErrorBoundaryProvider } from "./ErrorBoundaryProvider";
+
+const Boom = (): never => {
+  throw new Error("boom");
+};
+
+describe("ErrorBoundaryProvider", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders children when nothing throws", () => {
+    render(
+      <ErrorBoundaryProvider>
+        <div>safe content</div>
+      </ErrorBoundaryProvider>
+    );
+
+    expect(screen.getByText("safe content")).toBeInTheDocument();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("renders the fallback and reports the error to Sentry when a child throws", () => {
+    // React logs caught boundary errors to console.error; silence it.
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
+
+    render(
+      <ErrorBoundaryProvider>
+        <Boom />
+      </ErrorBoundaryProvider>
+    );
+
+    expect(screen.queryByText("safe content")).not.toBeInTheDocument();
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(Sentry.captureException).toHaveBeenCalledOnce();
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ contexts: expect.anything() })
+    );
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/apps/ui/src/app/providers/SentryUserSync.tsx
+++ b/apps/ui/src/app/providers/SentryUserSync.tsx
@@ -21,19 +21,18 @@ import { useMe } from "@/features/auth/Auth.queries";
  */
 export const SentryUserSync = (): null => {
   const me = useMe();
+  const userId = me.data?.user.id;
+  const userEmail = me.data?.user.email;
 
   useEffect(() => {
-    if (me.data?.user) {
-      Sentry.setUser({
-        id: me.data.user.id,
-        email: me.data.user.email
-      });
+    if (userId !== undefined && userEmail !== undefined) {
+      Sentry.setUser({ id: userId, email: userEmail });
 
       return;
     }
 
     Sentry.setUser(null);
-  }, [me.data?.user]);
+  }, [userId, userEmail]);
 
   return null;
 };

--- a/apps/ui/tests/setup.ts
+++ b/apps/ui/tests/setup.ts
@@ -48,3 +48,18 @@ if (typeof globalThis.EventSource === "undefined") {
 vi.mock("lottie-react", () => ({
   default: () => null
 }));
+
+/*
+ * Stub the Sentry SDK across the suite. With VITE_SENTRY_DSN unset Sentry
+ * is a no-op in production anyway, but an explicit mock keeps tests off the
+ * real SDK and lets specs assert capture/user calls. Covers the full surface
+ * the app uses (init / captureException / setUser / addBreadcrumb /
+ * browserTracingIntegration).
+ */
+vi.mock("@sentry/react", () => ({
+  init: vi.fn(),
+  captureException: vi.fn(),
+  setUser: vi.fn(),
+  addBreadcrumb: vi.fn(),
+  browserTracingIntegration: vi.fn(() => ({}))
+}));

--- a/infra/bootstrap/modules/bootstrap/templates/bootstrap.sh
+++ b/infra/bootstrap/modules/bootstrap/templates/bootstrap.sh
@@ -104,9 +104,11 @@ if [[ "$BACKUPS_ENABLED" == "true" ]]; then
   require_value backup_retention_days "$BACKUP_RETENTION_DAYS"
 
   log "Configuring nightly Postgres backups (rclone remote: $RCLONE_REMOTE_NAME)..."
-  # Install rclone if missing
+  # Install rclone if missing, from the distro's GPG-signed apt repo — never
+  # pipe a remote installer straight into a root shell.
   if ! command -v rclone >/dev/null 2>&1; then
-    curl -fsSL https://rclone.org/install.sh | bash
+    DEBIAN_FRONTEND=noninteractive apt-get update -y
+    DEBIAN_FRONTEND=noninteractive apt-get install -y rclone
   fi
   # Cron entry: 03:15 daily, log into syslog.
   CRON_LINE="15 3 * * * root RCLONE_REMOTE_NAME=$RCLONE_REMOTE_NAME RCLONE_REMOTE_PATH=$RCLONE_REMOTE_PATH BACKUP_RETENTION_DAYS=$BACKUP_RETENTION_DAYS $INFRA_DIR/scripts/backup-wrapper.example.sh 2>&1 | logger -t boringstack-backup"


### PR DESCRIPTION
## Summary

<!-- 1–3 bullets. What changed and why. -->

## Test plan

- [ ] `bun run check` (or `bun run check:full` for the cross-app pass) from the repo root
- [ ] Stack smoke if compose/infra touched: `cd infra/compose/compose && ./dev.sh up`

### App merge bars

| Area | Command |
|------|---------|
| API | `cd apps/api && bun run validate` |
| UI | `cd apps/ui && bun run validate` |
| Docs | `cd apps/docs && bun run build:ci` |
| Repo drift | `bun run check` (from repo root) |

## Conventions

- [ ] No `any`, no blind `as`, no `!`
- [ ] New env vars in schema + `.env.example` (+ SECURITY.md when relevant)
- [ ] Tests updated for changed behavior

## Screenshots

<!-- Required for UI changes. -->
