### PR TITLE
fix(ci): unique SARIF category per security workflow

### DIFF
--- a/.github/workflows/apps-api-security-deps.yml
+++ b/.github/workflows/apps-api-security-deps.yml
@@ -74,7 +74,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@7c1e4cf0b20d7c1872b26569c00ba908797a59bf # v4
         with:
           sarif_file: osv-results.sarif
-          category: osv-scanner
+          category: osv-scanner-api
         continue-on-error: true
 
       - name: Fail on osv findings

--- a/.github/workflows/apps-api-security-sast.yml
+++ b/.github/workflows/apps-api-security-sast.yml
@@ -92,5 +92,5 @@ jobs:
         uses: github/codeql-action/upload-sarif@7c1e4cf0b20d7c1872b26569c00ba908797a59bf # v4
         with:
           sarif_file: semgrep-results.sarif
-          category: semgrep
+          category: semgrep-api
         continue-on-error: true

--- a/.github/workflows/apps-api-security-secrets.yml
+++ b/.github/workflows/apps-api-security-secrets.yml
@@ -79,5 +79,5 @@ jobs:
         uses: github/codeql-action/upload-sarif@7c1e4cf0b20d7c1872b26569c00ba908797a59bf # v4
         with:
           sarif_file: gitleaks-results.sarif
-          category: gitleaks
+          category: gitleaks-api
         continue-on-error: true

--- a/.github/workflows/apps-docs-security-deps.yml
+++ b/.github/workflows/apps-docs-security-deps.yml
@@ -74,7 +74,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@7c1e4cf0b20d7c1872b26569c00ba908797a59bf # v4
         with:
           sarif_file: osv-results.sarif
-          category: osv-scanner
+          category: osv-scanner-docs
         continue-on-error: true
 
       - name: Fail on osv findings

--- a/.github/workflows/apps-docs-security-secrets.yml
+++ b/.github/workflows/apps-docs-security-secrets.yml
@@ -79,5 +79,5 @@ jobs:
         uses: github/codeql-action/upload-sarif@7c1e4cf0b20d7c1872b26569c00ba908797a59bf # v4
         with:
           sarif_file: gitleaks-results.sarif
-          category: gitleaks
+          category: gitleaks-docs
         continue-on-error: true

--- a/.github/workflows/apps-ui-security-deps.yml
+++ b/.github/workflows/apps-ui-security-deps.yml
@@ -72,7 +72,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@7c1e4cf0b20d7c1872b26569c00ba908797a59bf # v4
         with:
           sarif_file: osv-results.sarif
-          category: osv-scanner
+          category: osv-scanner-ui
         continue-on-error: true
 
       - name: Fail on osv findings

--- a/.github/workflows/apps-ui-security-sast.yml
+++ b/.github/workflows/apps-ui-security-sast.yml
@@ -91,5 +91,5 @@ jobs:
         uses: github/codeql-action/upload-sarif@7c1e4cf0b20d7c1872b26569c00ba908797a59bf # v4
         with:
           sarif_file: semgrep-results.sarif
-          category: semgrep
+          category: semgrep-ui
         continue-on-error: true

--- a/.github/workflows/apps-ui-security-secrets.yml
+++ b/.github/workflows/apps-ui-security-secrets.yml
@@ -79,5 +79,5 @@ jobs:
         uses: github/codeql-action/upload-sarif@7c1e4cf0b20d7c1872b26569c00ba908797a59bf # v4
         with:
           sarif_file: gitleaks-results.sarif
-          category: gitleaks
+          category: gitleaks-ui
         continue-on-error: true

--- a/.github/workflows/infra-bootstrap-security-secrets.yml
+++ b/.github/workflows/infra-bootstrap-security-secrets.yml
@@ -70,5 +70,5 @@ jobs:
         uses: github/codeql-action/upload-sarif@7c1e4cf0b20d7c1872b26569c00ba908797a59bf # v4
         with:
           sarif_file: gitleaks-results.sarif
-          category: gitleaks
+          category: gitleaks-bootstrap
         continue-on-error: true

--- a/.github/workflows/infra-compose-security-secrets.yml
+++ b/.github/workflows/infra-compose-security-secrets.yml
@@ -79,5 +79,5 @@ jobs:
         uses: github/codeql-action/upload-sarif@7c1e4cf0b20d7c1872b26569c00ba908797a59bf # v4
         with:
           sarif_file: gitleaks-results.sarif
-          category: gitleaks
+          category: gitleaks-compose
         continue-on-error: true


### PR DESCRIPTION
## Why
A push touching multiple areas fires several security workflows at once. They all uploaded their SARIF under the **same category** (`gitleaks` ×5, `semgrep` ×2, `osv-scanner` ×3). GitHub code scanning dedupes uploads by `(commit, ref, category)`, so the concurrent uploads collided and GitHub **cancelled** the stragglers. A cancelled step is not rescued by `continue-on-error` (that only covers *failures*), so a job surfaced as **failure on main** even though the scan passed and the PR was green.

This is exactly what happened right after #109 merged: the gitleaks scan passed but the `Upload SARIF` step was cancelled → red X on main.

## Fix
Give each workflow an area-scoped SARIF category so the uploads are distinct analyses that never collide:

| tool | categories |
|------|-----------|
| gitleaks | `gitleaks-api`, `gitleaks-ui`, `gitleaks-docs`, `gitleaks-compose`, `gitleaks-bootstrap` |
| semgrep | `semgrep-api`, `semgrep-ui` |
| osv-scanner | `osv-scanner-api`, `osv-scanner-ui`, `osv-scanner-docs` |

Bonus: code-scanning results are now attributable per area instead of clobbering each other.

10 files changed, 1 line each (only the `category:` value).