### PR TITLE
chore(deps): @casl/ability v7 parity (api) + drop @casl/react

### DIFF
--- a/apps/api/bun.lock
+++ b/apps/api/bun.lock
@@ -6,7 +6,7 @@
       "name": "boringstack-api",
       "dependencies": {
         "@anthropic-ai/sdk": "0.98.0",
-        "@casl/ability": "6.8.1",
+        "@casl/ability": "7.0.0",
         "@elysiajs/cors": "1.4.2",
         "@elysiajs/jwt": "1.4.2",
         "@elysiajs/swagger": "1.3.1",
@@ -127,7 +127,7 @@
 
     "@boring-stack-pkg/eslint-plugin-test-conventions": ["@boring-stack-pkg/eslint-plugin-test-conventions@0.1.2", "", { "dependencies": { "@typescript-eslint/utils": "8.0.0", "micromatch": "4.0.5" }, "peerDependencies": { "@typescript-eslint/parser": ">=8.0.0", "eslint": "8.57.0 || ^9.0.0", "typescript": ">=5.0.0" } }, "sha512-EmKoJ07RUA02TnkX7UqMNbQDbMBVB364i8p8Zbd99QNwdyJIKQZdg0f50C+NWlEBB2Lt0izzJODHxL6Og3Z4aA=="],
 
-    "@casl/ability": ["@casl/ability@6.8.1", "", { "dependencies": { "@ucast/mongo2js": "^1.3.0" } }, "sha512-VX5DD1JbSP/DdewZnNwXXaCzve+0pLe14mcUj2l93CdOFAQUT/ylAptNqxf3Wc/jlsuSanAgXza4Z1Iq23dzpQ=="],
+    "@casl/ability": ["@casl/ability@7.0.0", "", { "dependencies": { "@ucast/mongo2js": "^2.0.0" } }, "sha512-QhwRflkTucpdS2uw1XScrzLWbgLYJGvPoq2Xm5OjeRci3dwtPixxnjUKJ04Ss1ivNS9tZQ8y4sjWeelWsrwo4g=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
@@ -615,13 +615,13 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.60.0", "", { "dependencies": { "@typescript-eslint/types": "8.60.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg=="],
 
-    "@ucast/core": ["@ucast/core@1.10.2", "", {}, "sha512-ons5CwXZ/51wrUPfoduC+cO7AS1/wRb0ybpQJ9RrssossDxVy4t49QxWoWgfBDvVKsz9VXzBk9z0wqTdZ+Cq8g=="],
+    "@ucast/core": ["@ucast/core@2.0.0", "", {}, "sha512-4XVx6LzPXZGvnZO5jp39cm/G4UvuwvEdtmg+9+4+zl6uFkCcB7UJacvtMYeBE56GJVT99Zqy6Pii7dGJq3Kz9Q=="],
 
-    "@ucast/js": ["@ucast/js@3.1.0", "", { "dependencies": { "@ucast/core": "1.10.2" } }, "sha512-eJ7yQeYtMK85UZjxoxBEbTWx6UMxEXKbjVyp+NlzrT5oMKV5Gpo/9bjTl3r7msaXTVC8iD9NJacqJ8yp7joX+Q=="],
+    "@ucast/js": ["@ucast/js@4.0.1", "", { "dependencies": { "@ucast/core": "2.0.0" } }, "sha512-9O5xPBvwEWQk2WvO69Eh2WJB8QljVZ2vRVdFvfnKjlZwWXcYxp1lqLBhwXBU1AtuSgCvKhJPkXdjKJggUmAmQQ=="],
 
-    "@ucast/mongo": ["@ucast/mongo@2.4.3", "", { "dependencies": { "@ucast/core": "^1.4.1" } }, "sha512-XcI8LclrHWP83H+7H2anGCEeDq0n+12FU2mXCTz6/Tva9/9ddK/iacvvhCyW6cijAAOILmt0tWplRyRhVyZLsA=="],
+    "@ucast/mongo": ["@ucast/mongo@3.0.0", "", { "dependencies": { "@ucast/core": "2.0.0" } }, "sha512-kwuSH+kdB4GCR0LGhy/PEDm4PCflur89AlK82kNiYD0FvsA8A/p+0sx7m+/R8mMFAlmlkAd3VXp7sM/cLLYWYg=="],
 
-    "@ucast/mongo2js": ["@ucast/mongo2js@1.4.1", "", { "dependencies": { "@ucast/core": "1.10.2", "@ucast/js": "3.1.0", "@ucast/mongo": "2.4.3" } }, "sha512-9aeg5cmqwRQnKCXHN6I17wk83Rcm487bHelaG8T4vfpWneAI469wSI3Srnbu+PuZ5znWRbnwtVq9RgPL+bN6CA=="],
+    "@ucast/mongo2js": ["@ucast/mongo2js@2.0.0", "", { "dependencies": { "@ucast/core": "2.0.0", "@ucast/js": "4.0.1", "@ucast/mongo": "3.0.0" } }, "sha512-vNBZzRnsfLr/TSxEoxz6W6hHQ5tmWsfEeC0nCq5z8RezC1AqIRy3cfHm8AGvlGtcn+cTSFQcZremfqnz6wm+nQ=="],
 
     "@unhead/schema": ["@unhead/schema@1.11.20", "", { "dependencies": { "hookable": "^5.5.3", "zhead": "^2.2.4" } }, "sha512-0zWykKAaJdm+/Y7yi/Yds20PrUK7XabLe9c3IRcjnwYmSWY6z0Cr19VIs3ozCj8P+GhR+/TI2mwtGlueCEYouA=="],
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "0.98.0",
-    "@casl/ability": "6.8.1",
+    "@casl/ability": "7.0.0",
     "@elysiajs/cors": "1.4.2",
     "@elysiajs/jwt": "1.4.2",
     "@elysiajs/swagger": "1.3.1",

--- a/apps/ui/bun.lock
+++ b/apps/ui/bun.lock
@@ -6,7 +6,6 @@
       "name": "boringstack-ui",
       "dependencies": {
         "@casl/ability": "7.0.0",
-        "@casl/react": "6.0.0",
         "@hookform/resolvers": "5.2.2",
         "@sentry/react": "10.53.1",
         "@tanstack/react-query": "5.100.14",
@@ -170,8 +169,6 @@
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "3.2.1" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
     "@casl/ability": ["@casl/ability@7.0.0", "", { "dependencies": { "@ucast/mongo2js": "^2.0.0" } }, "sha512-QhwRflkTucpdS2uw1XScrzLWbgLYJGvPoq2Xm5OjeRci3dwtPixxnjUKJ04Ss1ivNS9tZQ8y4sjWeelWsrwo4g=="],
-
-    "@casl/react": ["@casl/react@6.0.0", "", { "peerDependencies": { "@casl/ability": "^4.0.0 || ^5.1.0 || ^6.0.0", "react": "^18.0.0 || ^19.0.0" } }, "sha512-XLjvUf/DLlS7AcRDXb3GtTrDGxQk09XDTWXs6tKdbeHqSWeydssngFJDFmf7MUtsza/BU+yXgS+C8j/RRx3MbA=="],
 
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.1.1", "", { "dependencies": { "@changesets/config": "3.1.4", "@changesets/get-version-range-type": "0.4.0", "@changesets/git": "3.0.4", "@changesets/should-skip-package": "0.1.2", "@changesets/types": "6.1.0", "@manypkg/get-packages": "1.1.3", "detect-indent": "6.1.0", "fs-extra": "7.0.1", "lodash.startcase": "4.4.0", "outdent": "0.5.0", "prettier": "2.8.8", "resolve-from": "5.0.0", "semver": "7.8.0" } }, "sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA=="],
 

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -59,7 +59,6 @@
   },
   "dependencies": {
     "@casl/ability": "7.0.0",
-    "@casl/react": "6.0.0",
     "@hookform/resolvers": "5.2.2",
     "@sentry/react": "10.53.1",
     "@tanstack/react-query": "5.100.14",

--- a/apps/ui/src/lib/acl/Can.tsx
+++ b/apps/ui/src/lib/acl/Can.tsx
@@ -1,12 +1,44 @@
-import { createContextualCan } from "@casl/react";
+import type { ReactNode } from "react";
 
-import { AbilityContext } from "./acl.context";
+import type { Action, Subject } from "./acl.types";
+import { useCan } from "./useCan";
+
+interface ICanProps {
+  /** Action to check, e.g. `"manage"`. */
+  readonly I: Action;
+  /** Subject to check the action against, e.g. `"Site"`. */
+  readonly a: Subject;
+  /** Invert the check — render when the ability *denies* the action. */
+  readonly not?: boolean;
+  /** Render children regardless; only meaningful with a render-prop child. */
+  readonly passThrough?: boolean;
+  readonly children: ReactNode | ((allowed: boolean) => ReactNode);
+}
 
 /**
  * Typed `<Can I="manage" a="Site">{children}</Can>` over the active
- * membership's ability. Wraps @casl/react's contextual consumer so call
- * sites don't have to thread the ability prop themselves.
+ * membership's ability (read from `<AbilityProvider>` via `useCan`).
+ *
+ * Replaces `@casl/react`'s `createContextualCan`, removed in v7. The rest of
+ * the ACL layer keeps its own typed `AbilityContext` + `emptyAbility` default
+ * (so a pre-`/me` tree denies everything), so binding `Can` to that context
+ * here is all that's needed.
  *
  * Render-gating only — the server enforces every action independently.
  */
-export const Can = createContextualCan(AbilityContext.Consumer);
+export function Can({
+  I,
+  a,
+  not = false,
+  passThrough = false,
+  children
+}: ICanProps): ReactNode {
+  const ability = useCan();
+  const allowed = not ? ability.cannot(I, a) : ability.can(I, a);
+
+  if (typeof children === "function") {
+    return children(allowed);
+  }
+
+  return allowed || passThrough ? children : null;
+}


### PR DESCRIPTION
Follow-up to #104, which bumped `@casl/ability` to 7.0.0 in **ui only**. This finishes the major upgrade:

- **api**: `@casl/ability` 6.8.1 → **7.0.0** — #104 left api on v6, so the shared ACL model (api defines abilities, ui mirrors them for render-gating) was split across majors. Now both on v7.
- **ui**: **drop `@casl/react`**. v7 removed `createContextualCan` (the only API the UI used), and #104 left `@casl/react@6` paired with `@casl/ability@7` — a peer mismatch. The small `<Can>` is reimplemented directly over the existing typed `AbilityContext`, so `@casl/react` is no longer needed and is removed (one fewer dep, no peer mismatch).

Keeping the template's deliberate `AbilityContext` + `emptyAbility`-default design (and its tests) rather than swapping to v7's `AbilityProvider`/`useAbility`. The rest of the ability surface (`createMongoAbility`, `AbilityBuilder`, `MongoAbility`, `ForcedSubject`, `subject`, `__caslSubjectType__`) is unchanged by v7.

## Validation
Full pre-push gate passed: api `validate` (integration + coverage 86.31%/83.17%), ui `validate`, security, smoke. `bun run check` (api + ui), ACL suites (**api 50, ui 13**), ui `build` all green; `bun install --frozen-lockfile` clean in both apps.

Ref #104.