### PR TITLE
docs: recommend Postgres + Valkey MCP servers for agent DX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ coverage/
 .bun-install/
 .audit/
 ROADMAP.md
+
+# Local MCP client config — copied from .mcp.json.example and may carry
+# machine-specific paths or credentials. The committed example is the source.
+.mcp.json

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,21 @@
+{
+  "mcpServers": {
+    "postgres": {
+      "command": "uvx",
+      "args": ["--python", "3.13", "postgres-mcp", "--access-mode=restricted"],
+      "env": {
+        "DATABASE_URI": "postgresql://app:app_dev_password@localhost:5432/app"
+      }
+    },
+    "valkey": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "redis-mcp-server@latest",
+        "redis-mcp-server",
+        "--url",
+        "redis://localhost:6379/0"
+      ]
+    }
+  }
+}

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -569,6 +569,7 @@ export default defineConfig({
           items: [
             { label: "Environment variables", link: "/reference/env-vars/" },
             { label: "Commands cheatsheet", link: "/reference/commands/" },
+            { label: "MCP servers for agents", link: "/reference/mcp-servers/" },
             {
               label: "Scripts & tooling",
               link: "/reference/scripts-tooling/",

--- a/apps/docs/src/content/docs/before-you-build.mdx
+++ b/apps/docs/src/content/docs/before-you-build.mdx
@@ -73,5 +73,6 @@ Open [Quickstart](/quickstart/) and start building. With a spec that holds up to
 ## Related
 
 - [Spec loop](/skills/spec-loop/), the spec-driven workflow for working with agents.
+- [MCP servers for agents](/reference/mcp-servers/), so the agent reads your live database and cache instead of guessing.
 - [Resources](/resources/), tools and reading that pair well with building a product.
 - [Quickstart](/quickstart/), where the code starts once the spec is ready.

--- a/apps/docs/src/content/docs/reference/mcp-servers.mdx
+++ b/apps/docs/src/content/docs/reference/mcp-servers.mdx
@@ -1,0 +1,123 @@
+---
+title: MCP servers for agents
+description: Point Postgres and Valkey MCP servers at the local dev stack so your coding agent can read the live schema, rows, cache keys, and queue state instead of guessing.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+A coding agent reads your code fine. It's blind to **runtime state**: the live
+database schema, the actual rows, the cache keys and their TTLs, the BullMQ
+queue backlog. So it guesses — and guesses drift from reality.
+
+[Model Context Protocol](https://modelcontextprotocol.io) servers close that
+gap. The dev stack already publishes Postgres and Valkey on the host (so you can
+`psql` and `valkey-cli` them), which means an MCP server reaches them with no
+extra setup. Same idea as observability: the runtime context is pre-wired —
+[for humans](/topics/observability/) in Grafana, and here for agents.
+
+This is dev-only and opt-in. Two servers, both read-leaning:
+
+| Server | Reach for it when… | What it gives the agent |
+| ------ | ------------------ | ----------------------- |
+| **Postgres** (read-only) | writing a Drizzle migration, debugging a query, checking a constraint | live schema, indexes, row samples, `EXPLAIN` plans, index/health analysis |
+| **Valkey / Redis** | a cache or TTL bug, a stuck job, inspecting rate-limit keys | keys, TTLs, `bull:*` queue state, `INFO` |
+
+## Setup
+
+1. Install [`uv`](https://docs.astral.sh/uv/) (provides `uvx`; the servers run
+   through it — no global installs):
+
+   ```bash
+   brew install uv      # or: curl -LsSf https://astral.sh/uv/install.sh | sh
+   ```
+
+2. Bring the dev stack up — this publishes Postgres on `5432` and Valkey on
+   `6379` (the `development-labels` overlay; production never exposes them):
+
+   ```bash
+   cd infra/compose/compose && ./dev.sh up -d
+   ```
+
+3. Copy the committed example into place. Your real config is gitignored, so
+   any local edits stay local:
+
+   ```bash
+   cp .mcp.json.example .mcp.json
+   ```
+
+4. Restart your agent (Claude Code, Cursor, any MCP client) and approve the two
+   servers when prompted.
+
+That's it — ask the agent to "list the tables" or "show the cache keys" and it
+queries the running stack.
+
+## What ships in `.mcp.json.example`
+
+```json
+{
+  "mcpServers": {
+    "postgres": {
+      "command": "uvx",
+      "args": ["--python", "3.13", "postgres-mcp", "--access-mode=restricted"],
+      "env": {
+        "DATABASE_URI": "postgresql://app:app_dev_password@localhost:5432/app"
+      }
+    },
+    "valkey": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "redis-mcp-server@latest",
+        "redis-mcp-server",
+        "--url",
+        "redis://localhost:6379/0"
+      ]
+    }
+  }
+}
+```
+
+- **Postgres** uses [`postgres-mcp`](https://github.com/crystaldba/postgres-mcp)
+  (Postgres MCP Pro). `--access-mode=restricted` is its **read-only** mode:
+  read queries and `EXPLAIN` only, wrapped in read-only transactions. The
+  `--python 3.13` pin sidesteps a missing wheel on newer Python builds.
+- **Valkey** uses the official
+  [`redis-mcp-server`](https://github.com/redis/mcp-redis) over the Redis wire
+  protocol (Valkey is a drop-in). The default values match the dev stack:
+  Postgres `app` / `app_dev_password` / db `app`, and Valkey DB `0` (the API's;
+  DB `1` is GlitchTip's).
+
+<Aside type="caution" title="Dev only — never point these at production">
+The credentials above are the throwaway local defaults, and the `5432`/`6379`
+host ports only exist under the dev overlay. Production keeps data services on
+the internal Docker network with real secrets. Never put a production
+connection string in `.mcp.json` — an agent with your prod DB in context is a
+breach waiting to happen.
+</Aside>
+
+<Aside type="tip" title="Read-only by default">
+`--access-mode=restricted` keeps the agent from mutating your dev database — it
+can read and explain, not write. For defense-in-depth you can also hand it a
+dedicated read-only role instead of `app`:
+
+```sql
+CREATE ROLE mcp_readonly LOGIN PASSWORD 'mcp_readonly';
+GRANT CONNECT ON DATABASE app TO mcp_readonly;
+GRANT USAGE ON SCHEMA public TO mcp_readonly;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO mcp_readonly;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO mcp_readonly;
+```
+
+Then swap the `DATABASE_URI` user to `mcp_readonly`. The Valkey server has no
+restricted mode; treat it as read/write and don't point it at anything you'd
+mind it changing.
+</Aside>
+
+## Why this fits the stack
+
+BoringStack's pitch is that [agents and humans get the same
+contract](/architecture/lint-as-contract/) — lint enforces the architecture for
+both. MCP extends that to runtime: the agent inspects the same database and
+cache you do, so its edits are grounded in what's actually there. Pair it with
+the [spec loop](/skills/spec-loop/) and the agent plans against real schema
+instead of an imagined one.


### PR DESCRIPTION
Building on BoringStack with a coding agent, the agent reads code fine but is blind to **runtime state** — live schema, rows, cache keys/TTLs, queue backlog — so it guesses. This wires MCP servers at the local dev stack to close that gap. Fills the `ROADMAP.md` Workstream-D "AI MCP recommendation" item.

## What's added
- **`.mcp.json.example`** (repo root, opt-in) — `cp .mcp.json.example .mcp.json` and the agent gets:
  - **Postgres (read-only)** via [`postgres-mcp`](https://github.com/crystaldba/postgres-mcp) `--access-mode=restricted` — schema, indexes, row samples, `EXPLAIN`. Pinned `--python 3.13` (newer Pythons lack a `pglast` wheel and fall back to a failing source build).
  - **Valkey/Redis** via the official [`redis-mcp-server`](https://github.com/redis/mcp-redis) — keys, TTLs, `bull:*` queue state.
  - Both via `uvx`; connection defaults match the dev stack (`app`/`app_dev_password`/`app`, Valkey DB 0).
- **`reference/mcp-servers.mdx`** — why, 4-step setup, a trigger→use table, dev-only + read-only cautions (incl. an optional read-only Postgres role), tie-back to *lint-as-contract* / *spec loop*. Sidebar entry under Reference + an inbound link from `before-you-build`.
- **`.gitignore`** — ignores the user's real `.mcp.json` (may carry creds); the example is the tracked source.

## Why it works with zero extra infra
The `development-labels` overlay already publishes Postgres `5432` and Valkey `6379` on the host "so developers can `psql`/`valkey-cli`" — production never does. So after `dev.sh up`, a host-run MCP server connects straight to the dev DBs.

## Validation
- Both servers install + run via the exact `uvx` commands in the example.
- The example's connection strings authenticate against the **running** dev Postgres (`SELECT` ok) and Valkey (`PONG`).
- `bun run build:ci` (docs) clean; pre-push gate (security + docs) passed.
- **Not automatable here:** the agent-speaks-MCP round trip. Verify in-editor: `cp .mcp.json.example .mcp.json`, open Claude Code, ask "list the tables" / "show the cache keys"; confirm a write through the Postgres server is refused (restricted mode).

Dev-DX only — no API/UI/prod runtime changes.