### PR TITLE
chore(audit): execute 2026-06-04 follow-up audit — test-sibling parity, billing query, push-refresh audit, docs peer-dep

### DIFF
--- a/apps/api/scripts/lint-meta/rules/testing/touch-tests-too.ts
+++ b/apps/api/scripts/lint-meta/rules/testing/touch-tests-too.ts
@@ -3,8 +3,16 @@ import { basename } from "node:path";
 
 import type { IMetaRule, IViolation } from "../../types";
 
+/*
+ * Logic/route suffixes that require a test. Kept a superset of
+ * logic-files-require-test-sibling's SUFFIX_REQUIRES_TEST
+ * (service|utils|jobs|check|channel|helpers) plus `routes` (guarded by
+ * routes-require-test-sibling). check/channel/helpers were missing here, so
+ * editing one without touching its test slipped past the opt-in touched-tests
+ * reminder even though the test sibling itself is mandatory.
+ */
 const TOUCHED_REQUIRES_TEST_PATTERN =
-  /^src\/.+\.(service|routes|utils|jobs)\.ts$/u;
+  /^src\/.+\.(service|routes|utils|jobs|check|channel|helpers)\.ts$/u;
 
 export function checkTouchedTests(baseRef: string, root: string): IViolation[] {
   const violations: IViolation[] = [];

--- a/apps/api/src/api/billing/billing.service.ts
+++ b/apps/api/src/api/billing/billing.service.ts
@@ -104,11 +104,16 @@ export class BillingService {
     await this.ensureConfiguredPlans();
 
     const [accountPlan, defaultPlan] = await Promise.all([
+      /*
+       * Eager-load the related plan in the same round-trip via the
+       * accountPlans→plan relation instead of a follow-up findFirst.
+       */
       db.query.accountPlans.findFirst({
         where: and(
           eq(accountPlans.accountId, accountId),
           isNull(accountPlans.revokedAt)
         ),
+        with: { plan: true },
       }),
       db.query.plans.findFirst({ where: eq(plans.isDefault, true) }),
     ]);
@@ -127,14 +132,8 @@ export class BillingService {
       };
     }
 
-    const plan = await db.query.plans.findFirst({
-      where: eq(plans.id, accountPlan.planId),
-    });
-
-    if (plan === undefined) {
-      throw ApiErrors.internal("Account plan references a missing plan row");
-    }
-
+    // plan is guaranteed by the not-null account_plans_plan_id_fkey FK.
+    const plan = accountPlan.plan;
     const stripeSubscriptionId = accountPlan.stripeSubscriptionId ?? "";
 
     return {

--- a/apps/api/src/api/notifications/notifications.push.service.ts
+++ b/apps/api/src/api/notifications/notifications.push.service.ts
@@ -57,6 +57,13 @@ export class NotificationsPushService {
           throw ApiErrors.internal("Failed to refresh push subscription");
         }
 
+        /* Without this, a silent key rotation leaves an audit-trail blind spot. */
+        void auditLogService.record({
+          userId: input.userId,
+          action: AUDIT_ACTIONS.NOTIFICATION_PUSH_SUBSCRIBED,
+          metadata: { subscriptionId: updated.id, refreshed: true },
+        });
+
         return toPublicPushSubscription(updated);
       }
 

--- a/apps/api/tests/api/notifications/notifications.push.service.test.ts
+++ b/apps/api/tests/api/notifications/notifications.push.service.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+  and,
+  auditLog,
   cleanDatabase,
   db,
   eq,
@@ -8,6 +10,7 @@ import {
   users,
 } from "../../helpers/db";
 import { notificationsPushService } from "../../../src/api/notifications/notifications.push.service";
+import { AUDIT_ACTIONS } from "../../../src/lib/audit-log";
 
 const insertTestUser = async (suffix: string): Promise<string> => {
   const [created] = await db
@@ -96,6 +99,45 @@ describe("NotificationsPushService.subscribe", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]?.p256dhKey).toBe("rotated-p256dh");
     expect(rows[0]?.authKey).toBe("rotated-auth");
+
+    /*
+     * record() is fire-and-forget (void), so the refresh audit row can land
+     * after subscribe() resolves — poll briefly (see tests/helpers/db.ts).
+     * The create and refresh both audit, so expect two rows for this user.
+     */
+    let auditRows: (typeof auditLog.$inferSelect)[] = [];
+
+    for (let attempt = 0; attempt < 20; attempt++) {
+      auditRows = await db
+        .select()
+        .from(auditLog)
+        .where(
+          and(
+            eq(auditLog.userId, userId),
+            eq(auditLog.action, AUDIT_ACTIONS.NOTIFICATION_PUSH_SUBSCRIBED)
+          )
+        );
+
+      if (auditRows.length >= 2) {
+        break;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+
+    expect(auditRows).toHaveLength(2);
+    expect(
+      auditRows.some((row) => {
+        const meta = row.metadata;
+
+        return (
+          typeof meta === "object" &&
+          meta !== null &&
+          "refreshed" in meta &&
+          meta.refreshed === true
+        );
+      })
+    ).toBe(true);
   });
 });
 

--- a/apps/api/tests/lint-meta/lint-meta.test.ts
+++ b/apps/api/tests/lint-meta/lint-meta.test.ts
@@ -1189,6 +1189,15 @@ describe("checkLogicFilesHaveTests", () => {
 });
 
 describe("checkTouchedTests", () => {
+  const GIT_ADD = "git add -A";
+
+  function initGitRepo(repo: string): void {
+    execSync("git init -q -b main", { cwd: repo });
+    execSync('git config user.email "test@example.com"', { cwd: repo });
+    execSync('git config user.name "Test"', { cwd: repo });
+    execSync("git config commit.gpgsign false", { cwd: repo });
+  }
+
   test("invalid base ref → silent skip (no violations)", () => {
     const violations = checkTouchedTests(
       "definitely-not-a-real-ref-xyz",
@@ -1202,10 +1211,7 @@ describe("checkTouchedTests", () => {
     const repo = mkdtempSync(join(tmpdir(), "lint-meta-touched-"));
 
     try {
-      execSync("git init -q -b main", { cwd: repo });
-      execSync('git config user.email "test@example.com"', { cwd: repo });
-      execSync('git config user.name "Test"', { cwd: repo });
-      execSync("git config commit.gpgsign false", { cwd: repo });
+      initGitRepo(repo);
 
       mkdirSync(join(repo, "src", "api"), { recursive: true });
       mkdirSync(join(repo, "tests", "api"), { recursive: true });
@@ -1218,14 +1224,14 @@ describe("checkTouchedTests", () => {
         join(repo, "tests", "api", "tickets.service.test.ts"),
         "import { describe } from 'bun:test';\ndescribe('placeholder', () => {});\n"
       );
-      execSync("git add -A", { cwd: repo });
+      execSync(GIT_ADD, { cwd: repo });
       execSync('git commit -q -m "init"', { cwd: repo });
 
       writeFileSync(
         join(repo, "src", "api", "tickets.service.ts"),
         "export const ticketsService = { add: () => 1 };\n"
       );
-      execSync("git add -A", { cwd: repo });
+      execSync(GIT_ADD, { cwd: repo });
       execSync('git commit -q -m "modify service without touching test"', {
         cwd: repo,
       });
@@ -1244,10 +1250,7 @@ describe("checkTouchedTests", () => {
     const repo = mkdtempSync(join(tmpdir(), "lint-meta-touched-"));
 
     try {
-      execSync("git init -q -b main", { cwd: repo });
-      execSync('git config user.email "test@example.com"', { cwd: repo });
-      execSync('git config user.name "Test"', { cwd: repo });
-      execSync("git config commit.gpgsign false", { cwd: repo });
+      initGitRepo(repo);
 
       mkdirSync(join(repo, "src", "api"), { recursive: true });
       mkdirSync(join(repo, "tests", "api"), { recursive: true });
@@ -1260,7 +1263,7 @@ describe("checkTouchedTests", () => {
         join(repo, "tests", "api", "tickets.service.test.ts"),
         "import { describe } from 'bun:test';\ndescribe('init', () => {});\n"
       );
-      execSync("git add -A", { cwd: repo });
+      execSync(GIT_ADD, { cwd: repo });
       execSync('git commit -q -m "init"', { cwd: repo });
 
       writeFileSync(
@@ -1271,12 +1274,51 @@ describe("checkTouchedTests", () => {
         join(repo, "tests", "api", "tickets.service.test.ts"),
         "import { describe, expect, test } from 'bun:test';\ntest('add', () => { expect(1).toBe(1); });\n"
       );
-      execSync("git add -A", { cwd: repo });
+      execSync(GIT_ADD, { cwd: repo });
       execSync('git commit -q -m "service + test together"', { cwd: repo });
 
       const violations = checkTouchedTests("HEAD~1", repo);
 
       expect(violations).toEqual([]);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("flags a .check.ts modified without its test (parity with logic-files suffixes)", () => {
+    const repo = mkdtempSync(join(tmpdir(), "lint-meta-touched-"));
+
+    try {
+      initGitRepo(repo);
+
+      mkdirSync(join(repo, "src", "checks"), { recursive: true });
+      mkdirSync(join(repo, "tests", "checks"), { recursive: true });
+
+      writeFileSync(
+        join(repo, "src", "checks", "database.check.ts"),
+        "export const databaseCheck = () => true;\n"
+      );
+      writeFileSync(
+        join(repo, "tests", "checks", "database.check.test.ts"),
+        "import { describe } from 'bun:test';\ndescribe('placeholder', () => {});\n"
+      );
+      execSync(GIT_ADD, { cwd: repo });
+      execSync('git commit -q -m "init"', { cwd: repo });
+
+      writeFileSync(
+        join(repo, "src", "checks", "database.check.ts"),
+        "export const databaseCheck = () => false;\n"
+      );
+      execSync(GIT_ADD, { cwd: repo });
+      execSync('git commit -q -m "modify check without touching test"', {
+        cwd: repo,
+      });
+
+      const violations = checkTouchedTests("HEAD~1", repo);
+
+      expect(violations.length).toBe(1);
+      expect(violations[0]?.rule).toBe("touch-tests-too");
+      expect(violations[0]?.message).toContain("database.check");
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }

--- a/apps/docs/bun.lock
+++ b/apps/docs/bun.lock
@@ -23,7 +23,7 @@
       "devDependencies": {
         "@axe-core/cli": "4.11.3",
         "http-server": "14.1.1",
-        "starlight-llms-txt": "0.6.1",
+        "starlight-llms-txt": "0.10.0",
         "wrangler": "4.94.0",
       },
     },
@@ -45,7 +45,7 @@
 
     "@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.1.2", "", { "dependencies": { "@astrojs/internal-helpers": "0.9.1", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "js-yaml": "^4.1.1", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "retext-smartypants": "^6.2.0", "shiki": "^4.0.0", "smol-toml": "^1.6.0", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q=="],
 
-    "@astrojs/mdx": ["@astrojs/mdx@4.3.14", "", { "dependencies": { "@astrojs/markdown-remark": "6.3.11", "@mdx-js/mdx": "3.1.1", "acorn": "8.16.0", "es-module-lexer": "1.7.0", "estree-util-visit": "2.0.0", "hast-util-to-html": "9.0.5", "piccolore": "0.1.3", "rehype-raw": "7.0.0", "remark-gfm": "4.0.1", "remark-smartypants": "3.0.2", "source-map": "0.7.6", "unist-util-visit": "5.1.0", "vfile": "6.0.3" }, "peerDependencies": { "astro": "5.18.1" } }, "sha512-FBrqJQORVm+rkRa2TS5CjU9PBA6hkhrwLVBSS9A77gN2+iehvjq1w6yya/d0YKC7osiVorKkr3Qd9wNbl0ZkGA=="],
+    "@astrojs/mdx": ["@astrojs/mdx@5.0.6", "", { "dependencies": { "@astrojs/markdown-remark": "7.1.2", "@mdx-js/mdx": "^3.1.1", "acorn": "^8.16.0", "es-module-lexer": "^2.0.0", "estree-util-visit": "^2.0.0", "hast-util-to-html": "^9.0.5", "piccolore": "^0.1.3", "rehype-raw": "^7.0.0", "remark-gfm": "^4.0.1", "remark-smartypants": "^3.0.2", "source-map": "^0.7.6", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3" }, "peerDependencies": { "astro": "^6.0.0" } }, "sha512-4dKe0ZMmqujofPNDHahzClkwinn9f8jHPcaXcgdGvPAlboD2mjzkUCofli2cBnxYAkdfhC6d50gBJ8i/cH8gHw=="],
 
     "@astrojs/prism": ["@astrojs/prism@4.0.2", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA=="],
 
@@ -1391,7 +1391,7 @@
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
-    "starlight-llms-txt": ["starlight-llms-txt@0.6.1", "", { "dependencies": { "@astrojs/mdx": "4.3.14", "@types/hast": "3.0.4", "@types/micromatch": "4.0.10", "github-slugger": "2.0.0", "hast-util-select": "6.0.4", "micromatch": "4.0.8", "rehype-parse": "9.0.1", "rehype-remark": "10.0.1", "remark-gfm": "4.0.1", "remark-stringify": "11.0.0", "unified": "11.0.5", "unist-util-remove": "4.0.0" }, "peerDependencies": { "@astrojs/starlight": "0.36.3", "astro": "5.18.1" } }, "sha512-V0XEj92hrWHCDOu2SiDbgPviKnlB/O4Fqh9yeDxjV+udw9y+mSQ+4Obhlj6UUhjn6gfoj0V7dPLM0Dhbd6j1NA=="],
+    "starlight-llms-txt": ["starlight-llms-txt@0.10.0", "", { "dependencies": { "@astrojs/mdx": "^5.0.4", "@types/hast": "^3.0.4", "@types/micromatch": "^4.0.10", "github-slugger": "^2.0.0", "hast-util-select": "^6.0.4", "micromatch": "^4.0.8", "rehype-parse": "^9.0.1", "rehype-remark": "^10.0.1", "remark-gfm": "^4.0.1", "remark-stringify": "^11.0.0", "unified": "^11.0.5", "unist-util-remove": "^4.0.0" }, "peerDependencies": { "@astrojs/starlight": ">=0.38.0", "astro": "^6.0.0" } }, "sha512-LgkSjkvdACsGHkFq1ES00F0BU4lRepjJoaUmOgxBxNWx4txwpySVPtntKdAvDvlhinyN0ZBRpnAsN/sVQ1UEfA=="],
 
     "stream-replace-string": ["stream-replace-string@2.0.0", "", {}, "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w=="],
 
@@ -1525,12 +1525,6 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
-    "@astrojs/mdx/@astrojs/markdown-remark": ["@astrojs/markdown-remark@6.3.11", "", { "dependencies": { "@astrojs/internal-helpers": "0.7.6", "@astrojs/prism": "3.3.0", "github-slugger": "2.0.0", "hast-util-from-html": "2.0.3", "hast-util-to-text": "4.0.2", "import-meta-resolve": "4.2.0", "js-yaml": "4.1.1", "mdast-util-definitions": "6.0.0", "rehype-raw": "7.0.0", "rehype-stringify": "10.0.1", "remark-gfm": "4.0.1", "remark-parse": "11.0.0", "remark-rehype": "11.1.2", "remark-smartypants": "3.0.2", "shiki": "3.23.0", "smol-toml": "1.6.1", "unified": "11.0.5", "unist-util-remove-position": "5.0.0", "unist-util-visit": "5.1.0", "unist-util-visit-parents": "6.0.2", "vfile": "6.0.3" } }, "sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ=="],
-
-    "@astrojs/mdx/es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
-
-    "@astrojs/starlight/@astrojs/mdx": ["@astrojs/mdx@5.0.6", "", { "dependencies": { "@astrojs/markdown-remark": "7.1.2", "@mdx-js/mdx": "^3.1.1", "acorn": "^8.16.0", "es-module-lexer": "^2.0.0", "estree-util-visit": "^2.0.0", "hast-util-to-html": "^9.0.5", "piccolore": "^0.1.3", "rehype-raw": "^7.0.0", "remark-gfm": "^4.0.1", "remark-smartypants": "^3.0.2", "source-map": "^0.7.6", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3" }, "peerDependencies": { "astro": "^6.0.0" } }, "sha512-4dKe0ZMmqujofPNDHahzClkwinn9f8jHPcaXcgdGvPAlboD2mjzkUCofli2cBnxYAkdfhC6d50gBJ8i/cH8gHw=="],
-
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/generator/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "3.1.2", "@jridgewell/sourcemap-codec": "1.5.5" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
@@ -1590,12 +1584,6 @@
     "vite/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
     "vitefu/vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "0.25.12", "fdir": "6.5.0", "picomatch": "4.0.4", "postcss": "8.5.14", "rollup": "4.60.3", "tinyglobby": "0.2.16" }, "optionalDependencies": { "@types/node": "24.12.2", "fsevents": "2.3.3", "jiti": "2.7.0", "lightningcss": "1.32.0" }, "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
-
-    "@astrojs/mdx/@astrojs/markdown-remark/@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.7.6", "", {}, "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q=="],
-
-    "@astrojs/mdx/@astrojs/markdown-remark/@astrojs/prism": ["@astrojs/prism@3.3.0", "", { "dependencies": { "prismjs": "1.30.0" } }, "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ=="],
-
-    "@astrojs/mdx/@astrojs/markdown-remark/shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "10.0.2", "@types/hast": "3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
 
     "@cloudflare/unenv-preset/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260430.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-ADohZUHf7NBvPp2PdZig2Opxx+hDkk3ve7jrTne3JRx9kDSB73zc4LzcEeEN8LKkbAcqZmvfRJfpChSlusu0lA=="],
 
@@ -1722,18 +1710,6 @@
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
     "vitefu/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
-
-    "@astrojs/mdx/@astrojs/markdown-remark/shiki/@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "10.0.2", "@types/hast": "3.0.4", "hast-util-to-html": "9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
-
-    "@astrojs/mdx/@astrojs/markdown-remark/shiki/@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "10.0.2", "oniguruma-to-es": "4.3.6" } }, "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA=="],
-
-    "@astrojs/mdx/@astrojs/markdown-remark/shiki/@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "10.0.2" } }, "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g=="],
-
-    "@astrojs/mdx/@astrojs/markdown-remark/shiki/@shikijs/langs": ["@shikijs/langs@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg=="],
-
-    "@astrojs/mdx/@astrojs/markdown-remark/shiki/@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
-
-    "@astrojs/mdx/@astrojs/markdown-remark/shiki/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "10.0.2", "@types/hast": "3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
 
     "vitefu/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@axe-core/cli": "4.11.3",
     "http-server": "14.1.1",
-    "starlight-llms-txt": "0.6.1",
+    "starlight-llms-txt": "0.10.0",
     "wrangler": "4.94.0"
   },
   "//overrides": {


### PR DESCRIPTION
Executes the follow-up 2026-06-04 audit (`.audit/audit-report.20260604-1048.done.json`). **4/4 done, 0 failed, 0 skipped.** Thin cycle — the repo is well-hardened after six prior rounds; api-core, ui-core and cross-cut came back clean.

## Findings

| ID | Sev | Fix | Guardrail |
|----|-----|-----|-----------|
| **F001** | medium | `touch-tests-too` matched `(service\|routes\|utils\|jobs)` while `logic-files-require-test-sibling` requires tests for `(service\|utils\|jobs\|check\|channel\|helpers)` — editing a `.check/.channel/.helpers.ts` slipped past the touched-tests reminder | Widened the pattern to the superset; regression test added |
| **F002** | medium (perf) | `BillingService.getSubscription` issued a 3rd sequential query for the account's plan | Eager-load via the `accountPlans→plan` relation; dropped the now-dead orphan guard (real not-null FK) |
| **F003** | low (security) | Push-subscription **refresh** (key rotation) recorded no audit entry while **create** did | Record on the update branch too (`metadata.refreshed`); flagged the cross-repo audit-log ESLint plugin which exempts `.update()` |
| **F004** | medium (deps) | `starlight-llms-txt@0.6.1` peer-pinned `astro ^5` while docs runs `astro 6.3.7` | Bumped to `0.10.0` (peers `astro ^6`); verified `llms.txt` still generates |

## Validation
- `bun run check` (api) green; `check:docs-data` green; `build:ci` green (llms outputs verified on Astro 6).
- Pre-push gate passed: gitleaks, semgrep, api validate, docs build + lychee linkcheck. (Smoke/e2e short-circuited — no smoke-relevant paths changed; CI runs the full smoke + Playwright suite on this PR.)

## Rejected during verification
- ui "extraneous deps" (`@casl/react`, `eslint-plugin-resource-architecture`, cva/next-themes/radix-ui) — `npm ls`/`knip --production` noise on a Bun repo; verified absent from `package.json`/`bun.lock` or used by shadcn.
- shellcheck SC1003/SC2001 style notes on correct code.

## Notes
- `.audit/audit-report.json` was renamed to `*.done.json`; `execution-summary.json` written.
- Two guardrails were considered but deliberately **not** added (would be unreliable as static checks): a peer-dependency-satisfaction rule (needs a semver resolver) and tightening the audit-log plugin (cross-repo).