### PR TITLE
chore(audit): execute 2026-06-04 (1130) audit — WUD no-new-privileges guardrail gap, docs catalog truncation

### DIFF
--- a/apps/docs/scripts/docs-catalog-lib.mjs
+++ b/apps/docs/scripts/docs-catalog-lib.mjs
@@ -136,6 +136,53 @@ function parseCommandName(cell, runner) {
   return stripped;
 }
 
+function firstSentence(paragraph) {
+  const collapsed = paragraph.replace(/\s+/gu, " ").trim();
+
+  if (collapsed === "") {
+    return "";
+  }
+
+  const sentence = /^(.*?[.!?])(?:\s|$)/u.exec(collapsed)?.[1];
+
+  if (sentence !== undefined) {
+    return sentence;
+  }
+
+  // No sentence terminator: this is a colon/semicolon lead-in (e.g.
+  // "Scaffolds a new API resource:") whose detail lives in an indented list
+  // we deliberately dropped. Normalize the dangling mark to a period so the
+  // catalog reads as a complete summary instead of a fragment.
+  return collapsed.replace(/[:;,]+$/u, ".");
+}
+
+// Assemble the first prose paragraph, then keep its first sentence. Lines that
+// the header indents (usage examples, bullet lists) end the paragraph — pulling
+// them in is exactly what produced mid-sentence cuts on the public docs site.
+function firstParagraphDescription(strippedLines) {
+  const paragraph = [];
+
+  for (const line of strippedLines) {
+    const isBoundary =
+      line.trim() === "" ||
+      /^\s/u.test(line) ||
+      line.startsWith("@") ||
+      /^Usage:/iu.test(line.trim());
+
+    if (isBoundary) {
+      if (paragraph.length > 0) {
+        break;
+      }
+
+      continue;
+    }
+
+    paragraph.push(line.trim());
+  }
+
+  return firstSentence(paragraph.join(" "));
+}
+
 function readScriptHeaderDescription(root, scriptPath) {
   const fullPath = join(root, "scripts", scriptPath);
 
@@ -146,14 +193,21 @@ function readScriptHeaderDescription(root, scriptPath) {
   const text = readFileSync(fullPath, "utf8");
 
   if (fullPath.endsWith(".sh")) {
-    const description = text
-      .split("\n")
-      .slice(0, 12)
-      .filter((line) => line.startsWith("#") && !line.startsWith("#!"))
-      .map((line) => line.replace(/^#\s?/u, "").trim())
-      .find((line) => line.length > 0);
+    const lines = [];
 
-    return description ?? "";
+    for (const line of text.split("\n")) {
+      if (line.startsWith("#!")) {
+        continue;
+      }
+
+      if (!line.startsWith("#")) {
+        break;
+      }
+
+      lines.push(line.replace(/^#\s?/u, ""));
+    }
+
+    return firstParagraphDescription(lines);
   }
 
   const block = /\/\*\*([\s\S]*?)\*\//u.exec(text)?.[1];
@@ -162,13 +216,66 @@ function readScriptHeaderDescription(root, scriptPath) {
     return "";
   }
 
-  const paragraph = block
-    .split("\n")
-    .map((line) => line.replace(/^\s*\*\s?/u, "").trim())
-    .filter((line) => line.length > 0 && !line.startsWith("@"))
-    .find((line) => !line.startsWith("Usage:"));
+  const lines = block.split("\n").map((line) => line.replace(/^\s*\*\s?/u, ""));
 
-  return paragraph ?? "";
+  return firstParagraphDescription(lines);
+}
+
+// A catalog description that ends on a conjunction/article/preposition, or
+// on a clause-joining mark, was cut mid-sentence by the extractor — the
+// generated docs render it verbatim on the public site. This set is the
+// guardrail: assertCatalogDescriptionsComplete refuses to emit such a
+// description, so truncation can never silently ship again.
+const DANGLING_TAIL = new Set([
+  "a", "an", "the", "and", "or", "but", "to", "of", "for", "with", "in",
+  "on", "at", "by", "from", "as", "that", "is", "are", "via", "into",
+  "when", "if", "so", "then", "than",
+]);
+
+export function isDescriptionComplete(description) {
+  const trimmed = description.trim();
+
+  if (trimmed === "") {
+    return true;
+  }
+
+  if (/[,;:]$/u.test(trimmed)) {
+    return false;
+  }
+
+  const lastWord = trimmed
+    .split(/\s+/u)
+    .at(-1)
+    ?.replace(/[^\p{L}\p{N}-]/gu, "")
+    .toLowerCase();
+
+  return lastWord === undefined || !DANGLING_TAIL.has(lastWord);
+}
+
+function assertCatalogDescriptionsComplete(catalog) {
+  const bad = [];
+
+  for (const [template, data] of Object.entries(catalog)) {
+    for (const command of data.commands) {
+      if (!isDescriptionComplete(command.description)) {
+        bad.push([`${template} ${command.command}`, command.description]);
+      }
+    }
+
+    for (const entry of data.manual) {
+      if (!isDescriptionComplete(entry.description)) {
+        bad.push([`${template} ${entry.task}`, entry.description]);
+      }
+    }
+  }
+
+  if (bad.length > 0) {
+    throw new Error(
+      `[docs] ${bad.length} script description(s) cut mid-sentence:\n${bad
+        .map(([label, description]) => `  ${label}: "…${description.slice(-48)}"`)
+        .join("\n")}`
+    );
+  }
 }
 
 function readPrePushStages(root) {
@@ -265,10 +372,14 @@ export function buildScriptsCatalog() {
   const uiRoot = resolveTemplateRoot("BORINGSTACK_UI_DIR", "ui");
   const apiRoot = resolveTemplateRoot("BORINGSTACK_API_DIR", "api");
 
-  return {
+  const catalog = {
     ui: buildTemplateScriptsCatalog(uiRoot, "ui", "bun run"),
     api: buildTemplateScriptsCatalog(apiRoot, "api", "bun run"),
   };
+
+  assertCatalogDescriptionsComplete(catalog);
+
+  return catalog;
 }
 
 export function writeOrCheck(outputPath, payload, checkMode) {

--- a/apps/docs/src/data/scripts-catalog.json
+++ b/apps/docs/src/data/scripts-catalog.json
@@ -28,25 +28,25 @@
       {
         "command": "dev",
         "script": "dev/preflight-host-dev.sh",
-        "description": "Refuses to run `bun run dev` on the host when the `ui-dev` compose",
+        "description": "Refuses to run `bun run dev` on the host when the `ui-dev` compose container is already up.",
         "invocation": "./scripts/dev/preflight-host-dev.sh && vite"
       },
       {
         "command": "size:check:modulepreload",
         "script": "quality/check-modulepreload-size-coverage.ts",
-        "description": "After `bun run build`, every `<link rel=\"modulepreload\">` in dist/index.html",
+        "description": "After `bun run build`, every `<link rel=\"modulepreload\">` in dist/index.html must match at least one glob in `.size-limit.json`.",
         "invocation": "tsx scripts/quality/check-modulepreload-size-coverage.ts"
       },
       {
         "command": "lint:meta",
         "script": "lint-meta/cli.ts",
-        "description": "Static checks for files ESLint can't parse as JavaScript:",
+        "description": "Static checks for files ESLint can't parse as JavaScript.",
         "invocation": "tsx scripts/lint-meta/cli.ts"
       },
       {
         "command": "lint:meta:verify",
         "script": "lint-meta/cli.ts",
-        "description": "Static checks for files ESLint can't parse as JavaScript:",
+        "description": "Static checks for files ESLint can't parse as JavaScript.",
         "invocation": "tsx scripts/lint-meta/cli.ts --verify"
       },
       {
@@ -100,7 +100,7 @@
       {
         "command": "pre-push",
         "script": "ci/pre-push.sh",
-        "description": "Local mirror of the UI app's CI gate. Runs everything CI runs so that a",
+        "description": "Local mirror of the UI app's CI gate.",
         "invocation": "./scripts/ci/pre-push.sh"
       }
     ],
@@ -163,25 +163,25 @@
       {
         "command": "dev",
         "script": "dev/preflight-host-dev.sh",
-        "description": "Refuses to run `bun run dev` on the host when the `api-dev` compose",
+        "description": "Refuses to run `bun run dev` on the host when the `api-dev` compose container is already up.",
         "invocation": "./scripts/dev/preflight-host-dev.sh && bun run build:templates && bun run --watch src/index.ts"
       },
       {
         "command": "db:seed",
         "script": "db/seed-superuser.ts",
-        "description": "Optional first-boot superuser bootstrap. Reads SUPERUSER_EMAIL and",
+        "description": "Optional first-boot superuser bootstrap.",
         "invocation": "bun run scripts/db/seed-superuser.ts"
       },
       {
         "command": "lint:meta",
         "script": "lint-meta/cli.ts",
-        "description": "Static checks for files ESLint can't parse as JavaScript:",
+        "description": "Static checks for files ESLint can't parse as JavaScript.",
         "invocation": "bun run scripts/lint-meta/cli.ts"
       },
       {
         "command": "lint:meta:verify",
         "script": "lint-meta/cli.ts",
-        "description": "Static checks for files ESLint can't parse as JavaScript:",
+        "description": "Static checks for files ESLint can't parse as JavaScript.",
         "invocation": "bun run scripts/lint-meta/cli.ts --verify"
       },
       {
@@ -205,7 +205,7 @@
       {
         "command": "new:resource",
         "script": "codegen/new-resource.ts",
-        "description": "Scaffolds a new API resource:",
+        "description": "Scaffolds a new API resource.",
         "invocation": "bun run scripts/codegen/new-resource.ts"
       },
       {
@@ -217,7 +217,7 @@
       {
         "command": "new:notification-event",
         "script": "codegen/new-notification-event.ts",
-        "description": "Scaffolds a new notification event:",
+        "description": "Scaffolds a new notification event.",
         "invocation": "bun run scripts/codegen/new-notification-event.ts"
       },
       {
@@ -247,19 +247,19 @@
       {
         "command": "generate:acl-types",
         "script": "codegen/generate-acl-types.ts",
-        "description": "Copies the canonical ACL type spine from apps/api to",
+        "description": "Copies the canonical ACL type spine from apps/api to apps/ui so the two workspace apps stay byte-identical on Role / Action / Subject / FeatureKey unions.",
         "invocation": "bun run scripts/codegen/generate-acl-types.ts"
       },
       {
         "command": "generate:acl-types:check",
         "script": "codegen/generate-acl-types.ts",
-        "description": "Copies the canonical ACL type spine from apps/api to",
+        "description": "Copies the canonical ACL type spine from apps/api to apps/ui so the two workspace apps stay byte-identical on Role / Action / Subject / FeatureKey unions.",
         "invocation": "bun run scripts/codegen/generate-acl-types.ts --check"
       },
       {
         "command": "pre-push",
         "script": "ci/pre-push.sh",
-        "description": "Local mirror of apps/api CI gate. Runs everything CI runs so that a",
+        "description": "Local mirror of apps/api CI gate.",
         "invocation": "./scripts/ci/pre-push.sh"
       },
       {

--- a/infra/compose/compose/docker-compose.wud.yml
+++ b/infra/compose/compose/docker-compose.wud.yml
@@ -29,6 +29,8 @@ services:
     image: getwud/wud:8.2.2@sha256:2df7cafa0fc84cdd66ad976163abc5390fa5995e0b5788a90e6a5303706bc21a
     profiles: [wud]
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
     environment:
       WUD_LOG_LEVEL: ${WUD_LOG_LEVEL:-info}
       WUD_WATCHER_LOCAL_CRON: ${WUD_SCHEDULE:-0 */6 * * *}

--- a/infra/compose/scripts/validate-guardrails.sh
+++ b/infra/compose/scripts/validate-guardrails.sh
@@ -34,16 +34,21 @@ render_prod_config() {
 render_full_config() {
   # Base prod stack plus every prod-capable overlay, so the hardening
   # checks see the optional services operators actually enable in
-  # production (observability, GlitchTip) alongside the dev-only ones.
+  # production (observability, GlitchTip, BullMQ, WUD). WUD is enabled by
+  # default when STACK=prod (dev.sh), so it MUST be rendered here or the
+  # privilege-escalation guardrail is blind to the one service that mounts
+  # the docker socket. Dev-only overlays (mailpit) are deliberately absent.
   docker compose \
     -f docker-compose.yml \
     -f docker-compose.observability.yml \
     -f docker-compose.glitchtip.yml \
     -f docker-compose.bullmq.yml \
+    -f docker-compose.wud.yml \
     --profile prod \
     --profile observability \
     --profile glitchtip-prod \
     --profile bullmq \
+    --profile wud \
     config --format json \
     > /tmp/guardrails-full-config.json 2>/dev/null
 }


### PR DESCRIPTION
## What

Executes the 2026-06-04 (1130) monorepo audit — both surviving findings, each a **guardrail gap** rather than an application bug, fixed guardrail-first.

### F001 — WUD missing `no-new-privileges`, and the guardrail was blind to it (`096e0c2`)
`whatsupdocker` is **prod-default** (`WITH_WUD=1` when `STACK=prod`) and bind-mounts `/var/run/docker.sock`, yet shipped without `security_opt: no-new-privileges:true`. Worse, `check_no_new_privileges` *claims* to cover "every long-running service — base AND optional overlay" but `render_full_config()` never rendered the `wud` overlay, so the one socket-mounting service in the stack was invisible to the check.

- Render the `wud` overlay in `render_full_config()` **first** → guardrail goes RED on `whatsupdocker`.
- Add `no-new-privileges:true` to the service → GREEN.
- The class now self-enforces for any future `wud`-overlay service.

Rejected the sibling Mailpit suggestion: Mailpit is dev-only (`dev.sh` gates `WITH_MAILPIT` on `STACK=dev`), so rendering it into a *prod*-config render would be semantically wrong.

### F002 — public scripts catalog shipped descriptions cut mid-sentence (`9d084c2`)
`readScriptHeaderDescription` kept only the first *physical* comment line, so wrapped headers truncated mid-sentence on boringstack.xyz (`db:seed` → "…Reads SUPERUSER_EMAIL **and**", `pre-push` → "…so that **a**").

- Assemble the first prose paragraph (indented usage examples / bullet lists are boundaries) and keep its first sentence; normalize a colon lead-in to a period.
- New `assertCatalogDescriptionsComplete` guardrail (runs in `generate:scripts-docs` **and** the `--check` path that `check:docs-data` / `build:ci` run in CI + pre-push) rejects any dangling description. It surfaced the **full class of 11** truncations, not just the 3 first spotted.

Dropped the `JSON.parse` error-message suggestion (advice-shaped, `enforceable:false`).

## Validation
- `bash infra/compose/scripts/validate-guardrails.sh all` — GREEN; `whatsupdocker` now in the enforced `no-new-privileges` list.
- `cd apps/docs && bun run check:docs-data` — GREEN.
- Full pre-push gate passed (compose-config all overlays, guardrails, shellcheck, yamllint; smoke stack booted).

## Audit context
6 of 8 audit cells returned zero findings (api-core, api-features, api-quality, ui-core, ui-quality, cross-cut). Both shipped findings were guardrail gaps — consistent with the maturing tree.
