### PR TITLE
chore(audit): execute 2026-06-04 (2055) audit — docs CI config triggers, env-var docs

### DIFF
--- a/.github/workflows/apps-docs-linkcheck.yml
+++ b/.github/workflows/apps-docs-linkcheck.yml
@@ -14,6 +14,13 @@ on:
       - "apps/docs/astro.config.mjs"
       - "apps/docs/package.json"
       - "apps/docs/bun.lock"
+      # Build/install/scan config: wrangler (Cloudflare asset + build settings),
+      # bunfig (install behavior), osv-scanner (vuln allowlist). A config-only
+      # push must still rebuild + linkcheck so a broken config can't land
+      # unverified.
+      - "apps/docs/wrangler.jsonc"
+      - "apps/docs/bunfig.toml"
+      - "apps/docs/osv-scanner.toml"
       - ".github/workflows/apps-docs-linkcheck.yml"
       # Catalog inputs: the generated docs data is derived from sibling-app
       # scripts/README.md, package.json scripts, and lint-meta export-catalog.

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -210,3 +210,11 @@ VALKEY_DB=0
 # Optional. Override only if you copy the precompiled email templates
 # (src/templates/email/dist) to a non-default location in your image.
 # EMAIL_TEMPLATES_DIR=/app/src/templates/email/dist
+
+# Optional, dev-only. Port for the email-template preview server
+# (`bun run preview:templates`); defaults to 3002. Read directly from the
+# environment rather than the validated env schema because it never runs in
+# the deployed app — so it stays commented here (an uncommented key would trip
+# the env-cascade-drift guardrail, which requires every .env.example key to
+# exist in src/config/env/schema.ts).
+# PREVIEW_PORT=3002

--- a/apps/docs/scripts/docs-catalog-lib.mjs
+++ b/apps/docs/scripts/docs-catalog-lib.mjs
@@ -5,6 +5,18 @@ import { fileURLToPath } from "node:url";
 
 const DOCS_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 
+/*
+ * Build-time only. Resolves a sibling template app's root for catalog
+ * generation. By default it assumes the monorepo layout (apps/<siblingName>
+ * next to apps/docs). Two optional env overrides exist for setups where that
+ * assumption breaks — shallow CI clones, isolated worktrees, or docs built
+ * outside the monorepo:
+ *   - BORINGSTACK_UI_DIR  — absolute path to the ui app (sibling default: ../ui)
+ *   - BORINGSTACK_API_DIR — absolute path to the api app (sibling default: ../api)
+ * Empty/unset falls back to the sibling path. These are internal contributor
+ * knobs, not product config, so they are documented here at the resolution
+ * point rather than in the published docs site.
+ */
 export function resolveTemplateRoot(envKey, siblingName) {
   const fromEnv = process.env[envKey];
 

--- a/apps/docs/scripts/pre-push.sh
+++ b/apps/docs/scripts/pre-push.sh
@@ -28,6 +28,10 @@ fail()    { c_red   "✗ $*"; exit 1; }
 ok()      { c_green "✓ $*"; }
 
 step "1/4 Docs data (monorepo apps)"
+# BORINGSTACK_UI_DIR / BORINGSTACK_API_DIR: optional absolute-path overrides
+# for the sibling app roots (defaults: ../ui, ../api). See resolveTemplateRoot
+# in scripts/docs-catalog-lib.mjs. Pass-through here so a non-monorepo layout
+# (shallow clone / worktree) can still locate the catalog source apps.
 BORINGSTACK_UI_DIR="$BORINGSTACK_UI_DIR" \
 BORINGSTACK_API_DIR="$BORINGSTACK_API_DIR" \
   bun run check:docs-data || fail "docs data drift: run bun run generate:docs-data from apps/docs"


### PR DESCRIPTION
## Summary

Executes the 2026-06-04 (2055) monorepo audit. After ~15 prior audit cycles this run was deliberately thin — 5 of 8 audit cells came back clean. Three low/medium findings landed; one was rejected during execution.

| Finding | Severity | Outcome |
| --- | --- | --- |
| **F002** docs linkcheck CI omitted build-affecting config files | medium | ✅ fixed |
| **F003** `PREVIEW_PORT` consumed but absent from `.env.example` | low | ✅ fixed |
| **F004** `BORINGSTACK_UI_DIR`/`BORINGSTACK_API_DIR` undocumented | low | ✅ fixed |
| **F001** prod `env_file` declared `required: false` | medium | ❌ reverted (not actionable) |

## Changes

- **F002 — `ci(docs)`**: added `apps/docs/wrangler.jsonc`, `bunfig.toml`, and `osv-scanner.toml` to the `apps-docs-linkcheck.yml` push `paths:`. A config-only push could previously land on `main` without the docs build/linkcheck running.
- **F003 — `docs(api)`**: documented `PREVIEW_PORT` as a **commented** stub in `apps/api/.env.example`, matching the `EMAIL_TEMPLATES_DIR` convention. `preview.ts` reads `process.env.PREVIEW_PORT` directly (outside the validated schema, dev-only). An uncommented key would trip the `env-cascade-drift` guardrail, which requires every `.env.example` key to exist in `schema.ts`.
- **F004 — `docs(docs)`**: documented the two build-time path-override env vars at `resolveTemplateRoot` (`docs-catalog-lib.mjs`) and the `pre-push.sh` pass-through site — where a debugger lands. They are internal contributor knobs, not product config, so they stay out of the published docs site.

## Rejected / not actionable

- **F001 (reverted):** the recommended fix (`required: true` on `api.prod.env`) broke the gate. The prod profile is validated by `docker compose config --profile prod` in CI, pre-push, and `validate-guardrails.sh` **without** a real `api.prod.env` present (prod secrets are runtime-only, not `${VAR:?}`-interpolated). `required: false` is load-bearing for that rendering. The fail-fast-on-missing-secrets benefit already exists via the API's boot-time env validator. A correct fix would live in a `dev.sh` up-time preflight, not the env_file flag.
- **API override asymmetry (ws/qs/tmp):** verified false during merge — `apps/api/bun.lock` has zero entries for these; overrides would pin absent packages.
- **OpenTofu `~>` constraints / short-form lock hashes, `pull_request_target` injection:** opinion / non-findings.

## Validation

- `cd apps/api && bun run check` — green (typecheck, lint, lint:meta, lint-meta-docs, knip)
- `cd apps/docs && bun run check:docs-data` — green (catalogs up to date)
- Full pre-push gate (compose config + guardrails + docs build + lychee linkcheck + root fan-out) — green