### PR TITLE
feat(infra): add k3s/ArgoCD GitOps deployment target + docs

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -533,6 +533,7 @@ export default defineConfig({
             },
             { label: "Resource limits", link: "/infra/resource-limits/" },
             { label: "Secrets", link: "/infra/secrets/" },
+            { label: "Kubernetes (k3s)", link: "/infra/kubernetes/" },
           ],
         },
         {
@@ -547,6 +548,10 @@ export default defineConfig({
             {
               label: "Provisioning with OpenTofu",
               link: "/topics/provisioning-with-tofu/",
+            },
+            {
+              label: "Provisioning with k3s (GitOps)",
+              link: "/topics/provisioning-with-k3s/",
             },
             {
               label: "Supply-chain protection",
@@ -607,6 +612,18 @@ export default defineConfig({
               link: "/runbooks/oauth-provider-setup/",
             },
             { label: "Codecov setup", link: "/runbooks/codecov-setup/" },
+            {
+              label: "ArgoCD image updater (k3s)",
+              link: "/runbooks/argocd-image-updater/",
+            },
+            {
+              label: "Secrets backends (k3s)",
+              link: "/runbooks/vault-secrets-operator/",
+            },
+            {
+              label: "Postgres backups (CNPG)",
+              link: "/runbooks/cnpg-backups/",
+            },
           ],
         },
         { label: "Resources", link: "/resources/" },

--- a/apps/docs/src/content/docs/infra/kubernetes.mdx
+++ b/apps/docs/src/content/docs/infra/kubernetes.mdx
@@ -1,0 +1,88 @@
+---
+title: "Infra template: Kubernetes (k3s)"
+description: Optional GitOps deployment target for any ArgoCD-managed k3s/Kubernetes cluster. Kustomize base + prod overlay, CloudNativePG, Traefik + cert-manager, per-project GlitchTip, swappable secrets.
+---
+
+`infra/k3s` is the **cluster** deployment target — the alternative to the
+single-host [`infra/compose`](/infra/overview/) and
+[OpenTofu/Hetzner](/topics/provisioning-with-tofu/) paths. Pick the one that
+fits your operating model; you don't need all three.
+
+It ships BoringStack to any ArgoCD-managed k3s/Kubernetes cluster as GitOps:
+push code → CI builds & pushes GHCR images → argocd-image-updater bumps the tag
+→ ArgoCD syncs. The whole app runs in one namespace with HA, autoscaling, and
+TLS.
+
+BoringStack is Compose-first on purpose, so this target lives in its own
+`infra/k3s/` subtree and is entirely opt-in — it never sits in the default
+deploy path.
+
+## What runs
+
+| Workload | Manifest | Notes |
+|---|---|---|
+| **api** | `base/api/` | Bun/Elysia, port 7330, `/health` (liveness) + `/ready` (readiness) |
+| **ui** | `base/ui/` | nginx static SPA, port 8080 |
+| **Postgres** | `base/postgres/` | CloudNativePG `Cluster` (1 → 3 instances in prod) |
+| **Valkey** | `base/valkey/` | in-namespace cache + BullMQ backend |
+| **GlitchTip** | `overlays/prod/glitchtip/` | per-project error tracking (web + worker) |
+| **migrations** | `base/api/migration-job.yaml` | ArgoCD PreSync Job: `db:migrate && db:seed` |
+
+Routing mirrors Compose prod — one domain, same-origin path routing:
+`Host && (/api or /health)` → api, everything else → ui (the SPA).
+
+## Layout
+
+```
+infra/k3s/
+├── argocd/        ArgoCD Application (+ image-updater) and registration example
+├── base/          env-agnostic manifests: namespace, api, ui, valkey, postgres
+└── overlays/prod/ HA + TLS + secrets + GlitchTip + monitoring + patches
+    └── secrets/   swappable backend: vault (default) | sealed | plain
+```
+
+`base/` is generic; `overlays/prod/` adds replicas/anti-affinity (api ×3, ui ×2,
+Postgres ×3), HPAs, PDBs, a ResourceQuota/LimitRange, Traefik middleware, the
+TLS `Certificate`, GlitchTip, and the monitoring integration.
+
+## Prerequisites
+
+The cluster must provide ArgoCD + argocd-image-updater, the CloudNativePG
+operator, cert-manager with a DNS-01 `ClusterIssuer`, Traefik (k3s default), and
+a persistent StorageClass. Optionally kube-prometheus-stack (for the
+ServiceMonitor + Grafana dashboards) and your chosen secrets backend.
+
+## Secrets are pluggable
+
+Every workload reads two plain k8s Secrets — `boringstack-secrets` (app env) and
+`ghcr-registry-secret` (GHCR pull) — plus the CNPG-generated `boringstack-db-app`
+(`DATABASE_URL`). The manifests never reference Vault directly, so *how* those
+Secrets are produced is a swappable Kustomize component under
+`overlays/prod/secrets/`:
+
+- **`vault`** (default) — HashiCorp Vault via the Vault Secrets Operator.
+- **`sealed`** — Bitnami SealedSecrets (encrypted, commit-safe).
+- **`plain`** — kustomize `secretGenerator` over a gitignored `secret.env`.
+
+Switch by editing one line in `overlays/prod/kustomization.yaml`. See the
+[secrets backends runbook](/runbooks/vault-secrets-operator/).
+
+## Monitoring
+
+The target does **not** deploy Prometheus/Grafana/Loki. It plugs into the
+cluster's kube-prometheus-stack via a `ServiceMonitor` (scrapes the api) and
+optional Grafana dashboard ConfigMaps. See
+`overlays/prod/monitoring/README.md`.
+
+## Get started
+
+Full knob list and walkthrough: [Provisioning with k3s](/topics/provisioning-with-k3s/)
+and `infra/k3s/README.md`.
+
+## Related
+
+- [Provisioning with k3s](/topics/provisioning-with-k3s/) — zero to live on a cluster.
+- [ArgoCD image updater](/runbooks/argocd-image-updater/) — the auto-deploy loop.
+- [Secrets backends (VSO / Sealed / plain)](/runbooks/vault-secrets-operator/).
+- [Postgres backups (CNPG)](/runbooks/cnpg-backups/).
+- [Infra overview](/infra/overview/) — the Compose-first single-host target.

--- a/apps/docs/src/content/docs/infra/overview.mdx
+++ b/apps/docs/src/content/docs/infra/overview.mdx
@@ -84,7 +84,7 @@ Every service has `deploy.resources.limits` and `reservations` driven by env var
 
 ## What's not in this template
 
-- Kubernetes manifests. This template is Compose-first; mixing Compose and cluster YAML in the starter would blur the deployment path BoringStack keeps intentionally clear.
+- Kubernetes manifests in *this* (Compose) target. BoringStack is Compose-first, and `infra/compose` deliberately stays cluster-free so the single-host path is clear. If you run a Kubernetes cluster and want GitOps, the opt-in [Kubernetes (k3s) target](/infra/kubernetes/) lives separately under `infra/k3s` — it never mixes into the Compose flow.
 - Application code. The apps/api and apps/ui own that.
 - Cloud-provider provisioning. The [OpenTofu bootstrap](/topics/provisioning-with-tofu/) in `infra/bootstrap` handles that.
 
@@ -95,3 +95,4 @@ Every service has `deploy.resources.limits` and `reservations` driven by env var
 - [Secrets](/infra/secrets/); how env values reach containers without leaking into images.
 - [Deployment](/topics/deployment/); the production runtime path end-to-end.
 - [Provisioning with OpenTofu](/topics/provisioning-with-tofu/); going from zero to a live VPS.
+- [Kubernetes (k3s)](/infra/kubernetes/); the opt-in GitOps target for a cluster you already run.

--- a/apps/docs/src/content/docs/runbooks/argocd-image-updater.mdx
+++ b/apps/docs/src/content/docs/runbooks/argocd-image-updater.mdx
@@ -1,0 +1,57 @@
+---
+title: ArgoCD image updater
+description: How the k3s target auto-deploys new builds — image-list, tag strategy, git write-back — and how to bootstrap and troubleshoot it.
+---
+
+The [k3s target](/infra/kubernetes/) closes the deploy loop with
+[argocd-image-updater](https://argocd-image-updater.readthedocs.io/): when CI
+pushes a new GHCR image, the updater rewrites the tag in
+`overlays/prod/kustomization.yaml` and ArgoCD syncs it. All config is
+annotations on `infra/k3s/argocd/boringstack-prod.yaml`.
+
+## The annotations
+
+```yaml
+argocd-image-updater.argoproj.io/image-list: api=ghcr.io/<owner>/<project>-api, ui=ghcr.io/<owner>/<project>-ui
+argocd-image-updater.argoproj.io/api.update-strategy: newest-build
+argocd-image-updater.argoproj.io/api.allow-tags: regexp:^[a-f0-9]{7,40}$
+argocd-image-updater.argoproj.io/write-back-method: git:secret:argocd/image-updater-git-creds
+argocd-image-updater.argoproj.io/write-back-target: kustomization
+argocd-image-updater.argoproj.io/git-branch: main
+```
+
+- **image-list** — `alias=image` pairs the updater watches.
+- **update-strategy / allow-tags** — `newest-build` + a git-SHA regex assumes CI
+  tags images with the commit SHA. If your CI publishes **semver** instead, use
+  `update-strategy: semver` and an allow-tags like `regexp:^v?\d+\.\d+\.\d+$`.
+- **write-back-method: git** — commits the tag bump back to your repo (GitOps
+  source of truth) using the `argocd/image-updater-git-creds` secret.
+- **write-back-target: kustomization** — edits the `images:` block, not the
+  Application spec.
+
+## Bootstrap
+
+1. Install argocd-image-updater in the `argocd` namespace.
+2. Create the git write-back credential it references:
+   ```bash
+   kubectl -n argocd create secret generic image-updater-git-creds \
+     --from-literal=username=<git-user> \
+     --from-literal=password=<git-PAT-or-deploy-token>
+   ```
+   (Or an `sshPrivateKey` key for SSH write-back.)
+3. Give it pull access to GHCR (a registry pull secret / `--registries-conf`)
+   so it can read tags from your private packages.
+
+## Troubleshooting
+
+- **No updates happen** — check the image-updater pod logs; confirm the
+  `allow-tags` regex matches the tags CI actually publishes.
+- **Updates detected but not committed** — the git creds secret is missing or
+  lacks push rights to `main`.
+- **Tag bumped but app didn't change** — confirm the Application's `images:`
+  block names match `image-list` exactly (registry + repo path).
+
+## Related
+
+- [Provisioning with k3s](/topics/provisioning-with-k3s/)
+- [Image updates (Compose / WUD)](/runbooks/image-updates/) — the Compose-path equivalent.

--- a/apps/docs/src/content/docs/runbooks/cnpg-backups.mdx
+++ b/apps/docs/src/content/docs/runbooks/cnpg-backups.mdx
@@ -1,0 +1,50 @@
+---
+title: Postgres backups (CNPG)
+description: Enable CloudNativePG barman backups to S3/R2 for the k3s target — credentials, store config, schedule — and how to restore.
+---
+
+The [k3s target](/infra/kubernetes/) runs Postgres via the
+[CloudNativePG](https://cloudnative-pg.io/) operator. HA (3 instances) is on by
+default in prod; **off-site backups are opt-in** so the default stack deploys
+without an object store configured.
+
+## Enable backups
+
+1. **Credentials** — provide an S3-compatible access key as a
+   `boringstack-backup` Secret (keys `ACCESS_KEY_ID` / `ACCESS_SECRET_KEY`). With
+   Vault, uncomment `vault-backup-secret.yaml` in
+   `overlays/prod/secrets/vault/kustomization.yaml` and seed:
+   ```bash
+   vault kv put secret/boringstack-backup \
+     AWS_ACCESS_KEY_ID=<key> AWS_SECRET_ACCESS_KEY=<secret>
+   ```
+
+2. **Store** — edit `overlays/prod/patches/postgres-backup.yaml`: set
+   `destinationPath` (e.g. `s3://my-bucket/boringstack`) and `endpointURL` (e.g.
+   your Cloudflare R2 endpoint). Adjust `retentionPolicy`.
+
+3. **Wire it up** — in `overlays/prod/kustomization.yaml`, uncomment:
+   - the `scheduled-backup.yaml` resource (runs every 4h via CNPG's 6-field cron)
+   - the `patches/postgres-backup.yaml` patch (attaches the barman store + enables WAL archiving)
+
+Sync. CNPG starts archiving WAL and taking base backups on schedule.
+
+## Verify
+
+```bash
+kubectl -n boringstack-prod get cluster boringstack-db -o jsonpath='{.status.conditions}'
+kubectl -n boringstack-prod get backups
+```
+
+## Restore
+
+CloudNativePG restores by bootstrapping a **new** Cluster from the object store
+(`bootstrap.recovery`) — you don't restore in place. See the
+[CNPG recovery docs](https://cloudnative-pg.io/documentation/current/recovery/);
+point a recovery `externalCluster` at the same `barmanObjectStore` and the
+`boringstack-backup` credentials.
+
+## Related
+
+- [Provisioning with k3s](/topics/provisioning-with-k3s/)
+- [Backups (Compose path)](/runbooks/backups/) — the single-host equivalent.

--- a/apps/docs/src/content/docs/runbooks/vault-secrets-operator.mdx
+++ b/apps/docs/src/content/docs/runbooks/vault-secrets-operator.mdx
@@ -1,0 +1,67 @@
+---
+title: Secrets backends (k3s)
+description: How the k3s target gets secrets into the cluster — the swappable Vault / Sealed Secrets / plain-env component — and how to seed Vault for the default path.
+---
+
+The [k3s target](/infra/kubernetes/) decouples *what the app reads* from *how
+secrets are stored*. Every workload consumes plain k8s Secrets —
+`boringstack-secrets` (app env) and `ghcr-registry-secret` (GHCR pull) — plus the
+CloudNativePG-generated `boringstack-db-app` (`DATABASE_URL`). The manifests never
+reference Vault directly, so the producer is a swappable Kustomize component in
+`overlays/prod/secrets/`.
+
+Switch backends by editing one line under `# Secrets backend (pick ONE)` in
+`overlays/prod/kustomization.yaml`.
+
+## Option A — Vault + Vault Secrets Operator (default)
+
+Requires Vault and the [VSO](https://developer.hashicorp.com/vault/docs/platform/k8s/vso)
+on the cluster. The component ships `VaultConnection`, `VaultAuth`, and
+`VaultStaticSecret` resources that sync Vault KV-v2 into the k8s Secrets.
+
+Seed Vault (KV-v2 mount `secret`):
+
+```bash
+# App env — every key the api validates (see infra/k3s/README.md)
+vault kv put secret/boringstack \
+  JWT_SECRET="$(openssl rand -base64 48)" \
+  MFA_ENCRYPTION_KEY="$(openssl rand -base64 32)" \
+  VALKEY_PASSWORD="$(openssl rand -base64 24)" \
+  GLITCHTIP_SECRET_KEY="$(openssl rand -base64 50)" \
+  FRONTEND_URL="https://<domain>" PUBLIC_API_URL="https://<domain>" \
+  QUEUES_ENABLED=true CACHE_PROVIDER=valkey \
+  # ...email / OAuth / Stripe / VAPID as needed...
+
+# GHCR pull creds — one key holding a full docker config.json
+vault kv put secret/boringstack-registry DOCKER_CONFIG_JSON=@dockerconfig.json
+```
+
+Bind a Vault Kubernetes-auth role so the operator can read those paths:
+
+```bash
+vault write auth/kubernetes/role/boringstack-prod-role \
+  bound_service_account_names=default \
+  bound_service_account_namespaces=boringstack-prod \
+  policies=boringstack-read ttl=10m
+```
+
+## Option B — Sealed Secrets
+
+No external Vault. Encrypt the two Secrets with `kubeseal` and commit the
+`SealedSecret` manifests; the Bitnami controller decrypts them in-cluster. Full
+steps in `overlays/prod/secrets/sealed/README.md`.
+
+## Option C — plain Secret from .env
+
+Simplest. Kustomize's `secretGenerator` builds `boringstack-secrets` from a
+gitignored `secret.env`; create `ghcr-registry-secret` with
+`kubectl create secret docker-registry`. Steps in
+`overlays/prod/secrets/plain/README.md`.
+
+<small>Pure-GitOps note: option C keeps secret values outside git, so it's best
+for a cluster you apply to yourself rather than a fully declarative pipeline.</small>
+
+## Related
+
+- [Provisioning with k3s](/topics/provisioning-with-k3s/)
+- [Kubernetes (k3s) infra reference](/infra/kubernetes/)

--- a/apps/docs/src/content/docs/topics/deployment.mdx
+++ b/apps/docs/src/content/docs/topics/deployment.mdx
@@ -11,6 +11,12 @@ or a manual SSH session. Step 4 verifies you're done.
 
 About thirty minutes of hands-on time on the first run.
 
+<Aside type="note" title="Already run a Kubernetes cluster?">
+  This guide covers the two single-host (docker-compose) paths. If you operate
+  an ArgoCD-managed k3s/Kubernetes cluster and want GitOps instead, see
+  [Provisioning with k3s](/topics/provisioning-with-k3s/).
+</Aside>
+
 ## 1. Accounts
 
 | Account | Why |

--- a/apps/docs/src/content/docs/topics/provisioning-with-k3s.mdx
+++ b/apps/docs/src/content/docs/topics/provisioning-with-k3s.mdx
@@ -1,0 +1,118 @@
+---
+title: Provisioning with k3s (GitOps)
+description: Ship BoringStack to any ArgoCD-managed k3s/Kubernetes cluster. Register one Application, seed secrets, and every CI build auto-deploys via argocd-image-updater.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+The cluster deployment path. Where [OpenTofu](/topics/provisioning-with-tofu/)
+gives you a single VPS running docker-compose, this gives you a GitOps loop on a
+Kubernetes cluster you already run: push code → CI publishes GHCR images →
+argocd-image-updater bumps the tag → ArgoCD syncs. HA, autoscaling, and TLS come
+with it.
+
+Source lives in [`infra/k3s`](https://github.com/boringstack-xyz/boringstack/tree/main/infra/k3s).
+
+<Aside type="note" title="One target among three">
+  BoringStack is Compose-first. Use this only if you already operate a
+  Kubernetes cluster and want GitOps. For a first VPS, the
+  [OpenTofu path](/topics/provisioning-with-tofu/) or
+  [manual deployment](/topics/deployment/) is simpler.
+</Aside>
+
+## Prerequisites
+
+A k3s/Kubernetes cluster with these operators installed:
+
+- **ArgoCD** + **argocd-image-updater** (with its `argocd/image-updater-git-creds` write-back secret)
+- **CloudNativePG** operator
+- **cert-manager** + a DNS-01-capable `ClusterIssuer`
+- **Traefik** (ships with k3s) exposing `web` + `websecure` entrypoints
+- a default/persistent **StorageClass**
+- *optional:* **kube-prometheus-stack** (metrics + dashboards), and a secrets
+  backend — **Vault + VSO** (default), or the **SealedSecrets** controller
+
+You'll also need CI that builds and pushes `ghcr.io/<owner>/<project>-api` and
+`-ui` images — the same pipeline the Compose/WUD path uses.
+
+## 1. Rebrand & set the knobs
+
+From your fork's root:
+
+```bash
+./scripts/rename-project.sh <project> <ghcr-owner> <domain>
+```
+
+That rewrites every `boringstack*` token across the repo, including the k3s
+manifests. Then edit the handful of cluster-specific values (all listed in
+`infra/k3s/README.md`):
+
+- the domain in `overlays/prod/ingress.yaml`, `certificate.yaml`, `glitchtip/`
+- the `ClusterIssuer` name in `overlays/prod/certificate.yaml`
+- the `StorageClass` in `base/postgres/cluster.yaml` + `base/valkey/statefulset.yaml` (optional; defaults to the cluster default)
+- `source.repoURL` in `argocd/boringstack-prod.yaml`
+
+## 2. Seed secrets
+
+Pick a backend in `overlays/prod/secrets/` (default Vault). For Vault, populate
+the KV-v2 paths and bind a role — see
+[Secrets backends](/runbooks/vault-secrets-operator/). The app's secret keys are
+listed in `infra/k3s/README.md` (`DATABASE_URL` is injected by CloudNativePG, so
+it's not among them).
+
+Add your fork to ArgoCD as a repo credential (an SSH deploy key for a private
+repo).
+
+## 3. Register the app with ArgoCD
+
+Either apply the Application directly:
+
+```bash
+kubectl apply -f infra/k3s/argocd/boringstack-prod.yaml
+```
+
+…or, if your cluster is an [app-of-apps](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/),
+drop `infra/k3s/argocd/app-of-apps-registration.example.yaml` into your
+app-of-apps repo (it points ArgoCD at your fork's `infra/k3s/argocd` directory).
+
+## How it works
+
+```mermaid
+flowchart LR
+  push["git push<br/>(app code)"]
+  ci["CI builds + pushes<br/>GHCR images"]
+  iu["argocd-image-updater<br/>bumps kustomization tag"]
+  argo["ArgoCD syncs<br/>overlays/prod"]
+  presync["PreSync Job<br/>db:migrate + db:seed"]
+  k8s["Rolling deploy<br/>api · ui · GlitchTip"]
+
+  push --> ci --> iu --> argo --> presync --> k8s
+```
+
+ArgoCD renders the prod overlay (base + secrets component + HA patches), runs the
+PreSync migration Job, then rolls out the Deployments. CloudNativePG manages
+Postgres; cert-manager issues the TLS cert; the Vault Secrets Operator (or your
+chosen backend) materializes the app secrets.
+
+## 4. Verify
+
+```bash
+kubectl -n boringstack-prod get pods            # all Running/Ready
+curl -sI https://<domain>/health                 # 200 from the api
+curl -sI https://<domain>/                        # 200 from the ui (SPA)
+```
+
+In ArgoCD the Application should be **Synced / Healthy**, and a new commit's
+image should auto-roll within an image-updater poll interval.
+
+## What stays manual / out of scope
+
+- Provisioning the cluster itself — bring your own k3s.
+- In-cluster Prometheus/Grafana/Loki — you integrate with the existing stack.
+
+## Related
+
+- [Kubernetes (k3s) infra reference](/infra/kubernetes/)
+- [ArgoCD image updater](/runbooks/argocd-image-updater/)
+- [Secrets backends](/runbooks/vault-secrets-operator/)
+- [Postgres backups (CNPG)](/runbooks/cnpg-backups/)

--- a/infra/k3s/README.md
+++ b/infra/k3s/README.md
@@ -1,0 +1,124 @@
+# infra/k3s — Kubernetes / GitOps deployment target
+
+A portable, opinionated way to ship BoringStack to **any** ArgoCD-managed
+k3s/Kubernetes cluster. This is the cluster alternative to the single-host
+[`infra/compose`](../compose) and [`infra/bootstrap`](../bootstrap) targets —
+pick the one that fits; you don't need all three.
+
+Push code → CI builds & pushes GHCR images → argocd-image-updater bumps the tag
+→ ArgoCD syncs. The full app (api, ui, Postgres, Valkey, GlitchTip) runs in one
+namespace with HA, autoscaling, and TLS.
+
+> This target is **Compose-first BoringStack's** opt-in cluster path. It is kept
+> in its own `infra/k3s/` subtree precisely so it never blurs the simpler
+> Compose deployment flow.
+
+## Layout
+
+```
+infra/k3s/
+├── argocd/        ArgoCD Application (+ image-updater) and registration example
+├── base/          env-agnostic manifests: namespace, api, ui, valkey, postgres
+└── overlays/prod/ HA + TLS + secrets + GlitchTip + monitoring + patches
+    └── secrets/   swappable secrets backend: vault (default) | sealed | plain
+```
+
+## Cluster prerequisites
+
+The target cluster must provide (all common, operator-installable):
+
+| Need | Used for |
+|------|----------|
+| ArgoCD + argocd-image-updater | GitOps sync + auto image bumps |
+| CloudNativePG operator | the Postgres `Cluster` |
+| cert-manager + a DNS-01 `ClusterIssuer` | TLS certs |
+| Traefik (k3s default) with `web`/`websecure` entrypoints | ingress |
+| a default/persistent StorageClass | Postgres + Valkey volumes |
+| **(optional)** kube-prometheus-stack | the ServiceMonitor + Grafana dashboards |
+| a secrets backend | Vault+VSO (default), or SealedSecrets controller |
+
+## The knobs to edit (per fork)
+
+1. **Rebrand**: `scripts/rename-project.sh <project> <ghcr-owner> <domain>` from
+   the repo root rewrites every `boringstack` / `boringstack-api` /
+   `boringstack-ui` / `boringstack-xyz` token across the repo, including these
+   manifests.
+2. **Domain**: replace `boringstack.example.com` (and
+   `glitchtip.boringstack.example.com`) in `overlays/prod/ingress.yaml`,
+   `certificate.yaml`, and `glitchtip/`.
+3. **ClusterIssuer**: set `issuerRef.name` in `overlays/prod/certificate.yaml`
+   to your cluster's DNS-01 issuer (`kubectl get clusterissuer`).
+4. **StorageClass**: uncomment/set `storageClass` in `base/postgres/cluster.yaml`
+   and `base/valkey/statefulset.yaml` if you don't want the cluster default.
+5. **Repo URL**: set `source.repoURL` in `argocd/boringstack-prod.yaml` to your
+   fork, and add it to ArgoCD as a repo credential.
+6. **Image tag strategy**: `argocd/boringstack-prod.yaml` assumes CI tags images
+   with the git SHA. If your CI uses semver, switch the `update-strategy` /
+   `allow-tags` annotations.
+
+## Secrets
+
+Workloads only ever read two k8s Secrets — `boringstack-secrets` (app env) and
+`ghcr-registry-secret` (GHCR pull) — plus the CNPG-generated `boringstack-db-app`
+(DATABASE_URL). *How* those get populated is the swappable component in
+`overlays/prod/secrets/`:
+
+- **`vault`** (default) — Vault + Vault Secrets Operator. Seed KV-v2 paths
+  `secret/boringstack`, `secret/boringstack-registry` (and `secret/boringstack-backup`
+  for backups), and bind a Vault role `boringstack-prod-role` to the
+  `boringstack-prod/default` ServiceAccount.
+- **`sealed`** — Bitnami SealedSecrets (commit encrypted manifests). See its README.
+- **`plain`** — kustomize `secretGenerator` over a gitignored `secret.env`. See its README.
+
+Swap by editing the one active line under `# Secrets backend (pick ONE)` in
+`overlays/prod/kustomization.yaml`.
+
+### App secret keys (`boringstack-secrets`)
+
+`DATABASE_URL` is injected by CNPG — do **not** put it here. Everything else the
+api validates at boot, e.g.:
+
+- **Required**: `JWT_SECRET`, `MFA_ENCRYPTION_KEY`, `VALKEY_PASSWORD`,
+  `FRONTEND_URL`, `PUBLIC_API_URL`, `QUEUES_ENABLED=true`, `CACHE_PROVIDER=valkey`
+- **Email** (one provider): `EMAIL_PROVIDER`, `EMAIL_FROM`, + provider keys
+  (`RESEND_API_KEY` / `SENDGRID_API_KEY` / `SMTP_*` / Cloudflare)
+- **GlitchTip**: `GLITCHTIP_SECRET_KEY`, `GLITCHTIP_SUPERUSER_EMAIL`,
+  `GLITCHTIP_SUPERUSER_PASSWORD`, optional `GLITCHTIP_EMAIL_URL`
+- **Optional**: OAuth (`*_OAUTH_CLIENT_ID/SECRET`), Stripe (`STRIPE_*`),
+  Web Push (`WEB_PUSH_VAPID_*`), AI (`AI_*`, `OPENAI_API_KEY`, …)
+
+`VALKEY_PASSWORD` is shared: the api, GlitchTip, and the Valkey StatefulSet's
+`--requirepass` all read it.
+
+## Deploy
+
+1. Rebrand + edit the knobs above.
+2. Ensure CI builds & pushes `ghcr.io/<owner>/<project>-api` and `-ui` (the UI
+   build must pass the `VITE_*` build args — `VITE_API_URL` empty for
+   same-origin, `VITE_SENTRY_DSN` = your GlitchTip DSN). This is the same image
+   pipeline the Compose/WUD path uses.
+3. Populate secrets via your chosen backend.
+4. Register with ArgoCD — either:
+   - `kubectl apply -f infra/k3s/argocd/boringstack-prod.yaml`, **or**
+   - add `argocd/app-of-apps-registration.example.yaml` to your app-of-apps repo.
+5. ArgoCD runs the PreSync migration Job (`db:migrate && db:seed`), then rolls
+   out the deployments. Watch it reach Healthy.
+
+## Verify
+
+```bash
+# Structural render (no cluster needed)
+kustomize build infra/k3s/overlays/prod | head
+
+# Live
+kubectl -n boringstack-prod get pods
+curl -sI https://<domain>/health        # -> 200 from the api
+curl -sI https://<domain>/              # -> 200 from the ui (SPA)
+```
+
+## What's intentionally not here
+
+- In-cluster Prometheus/Grafana/Loki — integrate with the cluster's stack
+  (`overlays/prod/monitoring/`).
+- Provisioning the cluster itself — bring your own k3s.
+- App code — that's `apps/api` and `apps/ui`.

--- a/infra/k3s/argocd/app-of-apps-registration.example.yaml
+++ b/infra/k3s/argocd/app-of-apps-registration.example.yaml
@@ -1,0 +1,32 @@
+# OPTIONAL — only if your cluster is managed by an ArgoCD "app-of-apps".
+#
+# Most clusters can skip this: just `kubectl apply -f boringstack-prod.yaml`
+# (the file next to this one) to register the product directly.
+#
+# If you run an app-of-apps whose root Application recurses an `apps/`
+# directory, drop a copy of THIS file into that repo (e.g. as
+# apps/external/boringstack.yaml). It points ArgoCD at your fork's
+# infra/k3s/argocd directory, which contains boringstack-prod.yaml. The
+# product's manifests stay self-contained in the fork; the cluster repo only
+# carries this one pointer.
+#
+# Replace <owner>/<your-fork> with your fork's repo.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: boringstack-apps
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: git@github.com:<owner>/<your-fork>.git
+    targetRevision: main
+    path: infra/k3s/argocd
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      selfHeal: true

--- a/infra/k3s/argocd/boringstack-prod.yaml
+++ b/infra/k3s/argocd/boringstack-prod.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: boringstack-prod
+  namespace: argocd
+  annotations:
+    # --- argocd-image-updater: auto-deploy new GHCR builds ----------------
+    # alias=full-image-path. The updater watches GHCR and writes the new tag
+    # back into overlays/prod/kustomization.yaml, which triggers a sync.
+    argocd-image-updater.argoproj.io/image-list: api=ghcr.io/boringstack-xyz/boringstack-api, ui=ghcr.io/boringstack-xyz/boringstack-ui
+    # Track newest git-SHA tag (matches a CI that tags images with the commit
+    # SHA). If your CI publishes semver instead, switch to `semver` and set
+    # allow-tags accordingly.
+    argocd-image-updater.argoproj.io/api.update-strategy: newest-build
+    argocd-image-updater.argoproj.io/api.allow-tags: regexp:^[a-f0-9]{7,40}$
+    argocd-image-updater.argoproj.io/ui.update-strategy: newest-build
+    argocd-image-updater.argoproj.io/ui.allow-tags: regexp:^[a-f0-9]{7,40}$
+    # Commit the tag bump back to git (GitOps source of truth).
+    argocd-image-updater.argoproj.io/write-back-method: git:secret:argocd/image-updater-git-creds
+    argocd-image-updater.argoproj.io/write-back-target: kustomization
+    argocd-image-updater.argoproj.io/git-branch: main
+spec:
+  project: default
+  source:
+    # Your fork's repo. Add it to ArgoCD as a repo credential (SSH deploy key
+    # for private repos).
+    repoURL: git@github.com:boringstack-xyz/boringstack.git
+    targetRevision: main
+    path: infra/k3s/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: boringstack-prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+  revisionHistoryLimit: 10

--- a/infra/k3s/base/api/deployment.yaml
+++ b/infra/k3s/base/api/deployment.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: boringstack
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      serviceAccountName: api
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: api
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          image: ghcr.io/boringstack-xyz/boringstack-api:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 7330
+              protocol: TCP
+          # All app secrets/config arrive as one Secret (`boringstack-secrets`),
+          # produced by the chosen secrets component in overlays/prod/secrets/*.
+          # The manifests never reference Vault directly — only this Secret —
+          # so Vault / Sealed Secrets / plain-env swap with a one-line change.
+          envFrom:
+            - secretRef:
+                name: boringstack-secrets
+          env:
+            # CloudNativePG publishes the app connection string here.
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: boringstack-db-app
+                  key: uri
+            # Infra topology (not secret): the in-namespace Valkey Service.
+            - name: VALKEY_HOST
+              value: valkey
+            - name: VALKEY_PORT
+              value: "6379"
+            - name: API_PORT
+              value: "7330"
+            - name: NODE_ENV
+              value: production
+            # Behind Traefik — read X-Forwarded-* for correct client IPs.
+            - name: TRUST_PROXY
+              value: "true"
+          # /health is a cheap liveness check; /ready aggregates db + valkey +
+          # queue + email and returns 503 until the app can actually serve.
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 7330
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 7330
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 7330
+            initialDelaySeconds: 0
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5"]
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"

--- a/infra/k3s/base/api/kustomization.yaml
+++ b/infra/k3s/base/api/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - networkpolicy.yaml
+  - rbac.yaml
+  - migration-job.yaml

--- a/infra/k3s/base/api/migration-job.yaml
+++ b/infra/k3s/base/api/migration-job.yaml
@@ -1,0 +1,69 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: api-migrations
+  namespace: boringstack
+  annotations:
+    # Runs before every sync, so schema is migrated before new pods roll out.
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app: api-migrations
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: api
+      imagePullSecrets:
+        - name: ghcr-registry-secret
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: migrate
+          image: ghcr.io/boringstack-xyz/boringstack-api:latest
+          imagePullPolicy: Always
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Running Drizzle migrations..."
+              bun run db:migrate
+              echo "Seeding..."
+              bun run db:seed
+              echo "Migrations complete."
+          envFrom:
+            - secretRef:
+                name: boringstack-secrets
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: boringstack-db-app
+                  key: uri
+            - name: VALKEY_HOST
+              value: valkey
+            - name: VALKEY_PORT
+              value: "6379"
+            - name: NODE_ENV
+              value: production
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"

--- a/infra/k3s/base/api/networkpolicy.yaml
+++ b/infra/k3s/base/api/networkpolicy.yaml
@@ -1,0 +1,63 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: api-network-policy
+  namespace: boringstack
+spec:
+  podSelector:
+    matchLabels:
+      app: api
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # From the Traefik ingress controller (k3s ships Traefik in kube-system).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+      ports:
+        - protocol: TCP
+          port: 7330
+  egress:
+    # DNS
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # PostgreSQL (CloudNativePG cluster, same namespace)
+    - to:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: boringstack-db
+      ports:
+        - protocol: TCP
+          port: 5432
+    # Valkey (in-namespace)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: valkey
+      ports:
+        - protocol: TCP
+          port: 6379
+    # External HTTPS (OAuth providers, email APIs, Stripe, AI providers, etc.)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443

--- a/infra/k3s/base/api/rbac.yaml
+++ b/infra/k3s/base/api/rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: api
+  namespace: boringstack
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: api-role
+  namespace: boringstack
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+    resourceNames: ["boringstack-secrets", "boringstack-db-app"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: api-rolebinding
+  namespace: boringstack
+subjects:
+  - kind: ServiceAccount
+    name: api
+    namespace: boringstack
+roleRef:
+  kind: Role
+  name: api-role
+  apiGroup: rbac.authorization.k8s.io

--- a/infra/k3s/base/api/service.yaml
+++ b/infra/k3s/base/api/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: boringstack
+  labels:
+    app: api
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 7330
+      targetPort: 7330
+      protocol: TCP
+  selector:
+    app: api

--- a/infra/k3s/base/kustomization.yaml
+++ b/infra/k3s/base/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Base namespace; the prod overlay flips this to `boringstack-prod`.
+namespace: boringstack
+
+resources:
+  - namespace.yaml
+  - postgres
+  - valkey
+  - api
+  - ui

--- a/infra/k3s/base/namespace.yaml
+++ b/infra/k3s/base/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: boringstack
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/infra/k3s/base/postgres/cluster.yaml
+++ b/infra/k3s/base/postgres/cluster.yaml
@@ -1,0 +1,30 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: boringstack-db
+  namespace: boringstack
+spec:
+  instances: 1
+  storage:
+    size: 10Gi
+    # Storage class is a per-cluster knob — see infra/k3s/README.md. Leave the
+    # line commented to use the cluster default, or set e.g. `longhorn`.
+    # storageClass: longhorn
+  postgresql:
+    parameters:
+      shared_buffers: "256MB"
+      max_connections: "100"
+  bootstrap:
+    initdb:
+      database: boringstack
+      owner: boringstack
+      # GlitchTip (the error-tracking overlay) shares this Postgres in its own
+      # database, owned by the same app role. postInitSQL runs once, as the
+      # superuser on the `postgres` database, at first bootstrap.
+      postInitSQL:
+        - CREATE DATABASE glitchtip OWNER boringstack;
+  # CloudNativePG publishes connection secrets:
+  #   boringstack-db-app  -> app role creds + `uri` for database `boringstack`
+  #   boringstack-db-rw   -> Service for the primary (read-write)
+  # Backups (barman -> S3/R2) are an opt-in overlay add-on; see
+  # overlays/prod/patches/postgres-backup.yaml and the README.

--- a/infra/k3s/base/postgres/kustomization.yaml
+++ b/infra/k3s/base/postgres/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - cluster.yaml
+  - networkpolicy.yaml

--- a/infra/k3s/base/postgres/networkpolicy.yaml
+++ b/infra/k3s/base/postgres/networkpolicy.yaml
@@ -1,0 +1,74 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: postgres-network-policy
+  namespace: boringstack
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: boringstack-db
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # From the API and GlitchTip pods.
+    - from:
+        - podSelector:
+            matchLabels:
+              app: api
+        - podSelector:
+            matchLabels:
+              app: glitchtip
+      ports:
+        - protocol: TCP
+          port: 5432
+    # CNPG intra-cluster replication.
+    - from:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: boringstack-db
+      ports:
+        - protocol: TCP
+          port: 5432
+    # CNPG operator status/metrics probes.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cnpg-system
+      ports:
+        - protocol: TCP
+          port: 8000
+        - protocol: TCP
+          port: 9187
+  egress:
+    # DNS
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # CNPG replication.
+    - to:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: boringstack-db
+      ports:
+        - protocol: TCP
+          port: 5432
+    # Kubernetes API server + external HTTPS (WAL archiving to S3/R2).
+    # Intentionally permissive on 443/6443 so CNPG's instance manager can
+    # reach the API server on any cluster topology. Tighten to your cluster's
+    # API/service CIDRs if you want a stricter policy.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443

--- a/infra/k3s/base/ui/deployment.yaml
+++ b/infra/k3s/base/ui/deployment.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ui
+  namespace: boringstack
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: ui
+  template:
+    metadata:
+      labels:
+        app: ui
+    spec:
+      serviceAccountName: ui
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ui
+          securityContext:
+            allowPrivilegeEscalation: false
+            # nginx in the prod image already runs as the non-root `app` user
+            # and writes only to emptyDir mounts below, so the root FS is RO.
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          # The SPA is a static nginx image; all VITE_* config is baked at
+          # build time in CI (VITE_API_URL empty = same-origin /api routing).
+          # No app secrets are mounted here.
+          image: ghcr.io/boringstack-xyz/boringstack-ui:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /index.html
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /index.html
+              port: 8080
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 8080
+            initialDelaySeconds: 0
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5"]
+          # nginx needs these paths writable; the prod image's user owns them.
+          volumeMounts:
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /run
+            - name: nginx-tmp
+              mountPath: /tmp/nginx
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
+      volumes:
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: nginx-tmp
+          emptyDir: {}

--- a/infra/k3s/base/ui/kustomization.yaml
+++ b/infra/k3s/base/ui/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - networkpolicy.yaml
+  - rbac.yaml

--- a/infra/k3s/base/ui/networkpolicy.yaml
+++ b/infra/k3s/base/ui/networkpolicy.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ui-network-policy
+  namespace: boringstack
+spec:
+  podSelector:
+    matchLabels:
+      app: ui
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # From the Traefik ingress controller only — the SPA is served to browsers.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    # DNS only. nginx serves static assets; the browser calls /api directly
+    # through the ingress (same-origin), so the UI pod makes no server-side
+    # calls to the API.
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/infra/k3s/base/ui/rbac.yaml
+++ b/infra/k3s/base/ui/rbac.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ui
+  namespace: boringstack

--- a/infra/k3s/base/ui/service.yaml
+++ b/infra/k3s/base/ui/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ui
+  namespace: boringstack
+  labels:
+    app: ui
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: ui

--- a/infra/k3s/base/valkey/kustomization.yaml
+++ b/infra/k3s/base/valkey/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - statefulset.yaml
+  - service.yaml
+  - networkpolicy.yaml
+  - rbac.yaml

--- a/infra/k3s/base/valkey/networkpolicy.yaml
+++ b/infra/k3s/base/valkey/networkpolicy.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: valkey-network-policy
+  namespace: boringstack
+spec:
+  podSelector:
+    matchLabels:
+      app: valkey
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # From the API and GlitchTip pods only.
+    - from:
+        - podSelector:
+            matchLabels:
+              app: api
+        - podSelector:
+            matchLabels:
+              app: glitchtip
+      ports:
+        - protocol: TCP
+          port: 6379
+  egress:
+    # DNS
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/infra/k3s/base/valkey/rbac.yaml
+++ b/infra/k3s/base/valkey/rbac.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: valkey
+  namespace: boringstack

--- a/infra/k3s/base/valkey/service.yaml
+++ b/infra/k3s/base/valkey/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: valkey
+  namespace: boringstack
+  labels:
+    app: valkey
+spec:
+  type: ClusterIP
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+      protocol: TCP
+  selector:
+    app: valkey

--- a/infra/k3s/base/valkey/statefulset.yaml
+++ b/infra/k3s/base/valkey/statefulset.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: valkey
+  namespace: boringstack
+  labels:
+    app: valkey
+spec:
+  serviceName: valkey
+  replicas: 1
+  selector:
+    matchLabels:
+      app: valkey
+  template:
+    metadata:
+      labels:
+        app: valkey
+    spec:
+      serviceAccountName: valkey
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: valkey
+          image: valkey/valkey:8-alpine
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - valkey-server
+          args:
+            # Cache + BullMQ queue backend. Light persistence (RDB) to /data so
+            # queued jobs survive a restart; flip --save "" + --appendonly no for
+            # a pure cache. requirepass must equal the password the API sends.
+            - --dir
+            - /data
+            - --save
+            - "60"
+            - "1000"
+            - --appendonly
+            - "no"
+            - --maxmemory-policy
+            - noeviction
+            - --requirepass
+            - $(VALKEY_PASSWORD)
+          env:
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: boringstack-secrets
+                  key: VALKEY_PASSWORD
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - valkey-cli -a "$VALKEY_PASSWORD" ping | grep -q PONG
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        # Storage class is a per-cluster knob — see infra/k3s/README.md.
+        # Leave unset to use the cluster default, or set e.g. `longhorn`.
+        # storageClassName: longhorn
+        resources:
+          requests:
+            storage: 2Gi

--- a/infra/k3s/overlays/prod/certificate.yaml
+++ b/infra/k3s/overlays/prod/certificate.yaml
@@ -1,0 +1,18 @@
+# TLS certificate for the app + GlitchTip subdomain.
+# Prerequisites:
+#   - cert-manager installed in the cluster
+#   - a DNS-01-capable ClusterIssuer (verify name: kubectl get clusterissuer)
+# The issuer name below is a per-cluster knob — see infra/k3s/README.md.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: boringstack-tls
+  namespace: boringstack-prod
+spec:
+  secretName: boringstack-tls
+  issuerRef:
+    name: letsencrypt-dns01
+    kind: ClusterIssuer
+  dnsNames:
+    - boringstack.example.com
+    - glitchtip.boringstack.example.com

--- a/infra/k3s/overlays/prod/glitchtip/deployment-web.yaml
+++ b/infra/k3s/overlays/prod/glitchtip/deployment-web.yaml
@@ -1,0 +1,126 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: glitchtip-web
+  namespace: boringstack-prod
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: glitchtip
+      component: web
+  template:
+    metadata:
+      labels:
+        app: glitchtip
+        component: web
+    spec:
+      imagePullSecrets:
+        - name: ghcr-registry-secret
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: glitchtip-web
+          image: glitchtip/glitchtip:6.1.6
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          env:
+            # CNPG app-role creds; GlitchTip uses its own `glitchtip` database
+            # (created via postInitSQL) on the read-write primary Service.
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: boringstack-db-app
+                  key: username
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: boringstack-db-app
+                  key: password
+            - name: DATABASE_URL
+              value: postgres://$(DB_USER):$(DB_PASS)@boringstack-db-rw:5432/glitchtip
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: boringstack-secrets
+                  key: VALKEY_PASSWORD
+            - name: REDIS_URL
+              value: redis://:$(VALKEY_PASSWORD)@valkey:6379/1
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: boringstack-secrets
+                  key: GLITCHTIP_SECRET_KEY
+            - name: PORT
+              value: "8000"
+            - name: GLITCHTIP_DOMAIN
+              value: https://glitchtip.boringstack.example.com
+            - name: DEFAULT_FROM_EMAIL
+              value: noreply@example.com
+            - name: EMAIL_URL
+              valueFrom:
+                secretKeyRef:
+                  name: boringstack-secrets
+                  key: GLITCHTIP_EMAIL_URL
+                  optional: true
+            - name: CELERY_WORKER_AUTOSCALE
+              value: "1,3"
+            - name: CELERY_WORKER_MAX_TASKS_PER_CHILD
+              value: "10000"
+            # First-boot setup (only applied while the DB is empty).
+            - name: GLITCHTIP_SUPERUSER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: boringstack-secrets
+                  key: GLITCHTIP_SUPERUSER_EMAIL
+                  optional: true
+            - name: GLITCHTIP_SUPERUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: boringstack-secrets
+                  key: GLITCHTIP_SUPERUSER_PASSWORD
+                  optional: true
+            - name: GLITCHTIP_DEFAULT_ORG_NAME
+              value: BoringStack
+            - name: GLITCHTIP_DEFAULT_PROJECTS
+              value: API,Frontend
+          # The image ships no wget/curl; probe /_health/ with bundled python3.
+          startupProbe:
+            exec:
+              command:
+                ["python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/_health/', timeout=3)"]
+            periodSeconds: 5
+            failureThreshold: 30
+          livenessProbe:
+            exec:
+              command:
+                ["python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/_health/', timeout=3)"]
+            periodSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                ["python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/_health/', timeout=3)"]
+            periodSeconds: 15
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "1000m"

--- a/infra/k3s/overlays/prod/glitchtip/deployment-worker.yaml
+++ b/infra/k3s/overlays/prod/glitchtip/deployment-worker.yaml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: glitchtip-worker
+  namespace: boringstack-prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: glitchtip
+      component: worker
+  template:
+    metadata:
+      labels:
+        app: glitchtip
+        component: worker
+    spec:
+      imagePullSecrets:
+        - name: ghcr-registry-secret
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: glitchtip-worker
+          image: glitchtip/glitchtip:6.1.6
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          command: ["./bin/run-celery-with-beat.sh"]
+          env:
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: boringstack-db-app
+                  key: username
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: boringstack-db-app
+                  key: password
+            - name: DATABASE_URL
+              value: postgres://$(DB_USER):$(DB_PASS)@boringstack-db-rw:5432/glitchtip
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: boringstack-secrets
+                  key: VALKEY_PASSWORD
+            - name: REDIS_URL
+              value: redis://:$(VALKEY_PASSWORD)@valkey:6379/1
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: boringstack-secrets
+                  key: GLITCHTIP_SECRET_KEY
+            - name: GLITCHTIP_DOMAIN
+              value: https://glitchtip.boringstack.example.com
+            - name: DEFAULT_FROM_EMAIL
+              value: noreply@example.com
+            - name: EMAIL_URL
+              valueFrom:
+                secretKeyRef:
+                  name: boringstack-secrets
+                  key: GLITCHTIP_EMAIL_URL
+                  optional: true
+            - name: CELERY_WORKER_AUTOSCALE
+              value: "1,3"
+            - name: CELERY_WORKER_MAX_TASKS_PER_CHILD
+              value: "10000"
+          # The worker has no HTTP port and the image ships only python3, so
+          # probe liveness by scanning /proc for the runworker process.
+          livenessProbe:
+            exec:
+              command:
+                - python3
+                - -c
+                - |
+                  import os, sys
+                  me = str(os.getpid())
+                  def alive():
+                      for pid in os.listdir("/proc"):
+                          if not pid.isdigit() or pid == me:
+                              continue
+                          try:
+                              with open(f"/proc/{pid}/cmdline", "rb") as fh:
+                                  if b"runworker" in fh.read():
+                                      return True
+                          except OSError:
+                              continue
+                      return False
+                  sys.exit(0 if alive() else 1)
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "1000m"

--- a/infra/k3s/overlays/prod/glitchtip/ingress.yaml
+++ b/infra/k3s/overlays/prod/glitchtip/ingress.yaml
@@ -1,0 +1,35 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: glitchtip-http-redirect
+  namespace: boringstack-prod
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Host(`glitchtip.boringstack.example.com`)
+      kind: Rule
+      middlewares:
+        - name: redirect-https
+      services:
+        - name: glitchtip-web
+          port: 8000
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: glitchtip
+  namespace: boringstack-prod
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`glitchtip.boringstack.example.com`)
+      kind: Rule
+      middlewares:
+        - name: security-headers
+      services:
+        - name: glitchtip-web
+          port: 8000
+  tls:
+    secretName: boringstack-tls

--- a/infra/k3s/overlays/prod/glitchtip/kustomization.yaml
+++ b/infra/k3s/overlays/prod/glitchtip/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment-web.yaml
+  - deployment-worker.yaml
+  - service.yaml
+  - ingress.yaml
+  - networkpolicy.yaml

--- a/infra/k3s/overlays/prod/glitchtip/networkpolicy.yaml
+++ b/infra/k3s/overlays/prod/glitchtip/networkpolicy.yaml
@@ -1,0 +1,63 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: glitchtip-network-policy
+  namespace: boringstack-prod
+spec:
+  podSelector:
+    matchLabels:
+      app: glitchtip
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # web UI/ingest from Traefik; the SDK in the api pod also ingests events.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+        - podSelector:
+            matchLabels:
+              app: api
+      ports:
+        - protocol: TCP
+          port: 8000
+  egress:
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: boringstack-db
+      ports:
+        - protocol: TCP
+          port: 5432
+    - to:
+        - podSelector:
+            matchLabels:
+              app: valkey
+      ports:
+        - protocol: TCP
+          port: 6379
+    # Outbound HTTPS (alert webhooks, email APIs).
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443

--- a/infra/k3s/overlays/prod/glitchtip/service.yaml
+++ b/infra/k3s/overlays/prod/glitchtip/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: glitchtip-web
+  namespace: boringstack-prod
+  labels:
+    app: glitchtip
+    component: web
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+      protocol: TCP
+  selector:
+    app: glitchtip
+    component: web

--- a/infra/k3s/overlays/prod/hpa.yaml
+++ b/infra/k3s/overlays/prod/hpa.yaml
@@ -1,0 +1,75 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: api-hpa
+  namespace: boringstack-prod
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: api
+  minReplicas: 3
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 10
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 15
+        - type: Pods
+          value: 4
+          periodSeconds: 15
+      selectPolicy: Max
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: ui-hpa
+  namespace: boringstack-prod
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: ui
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 10
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 15

--- a/infra/k3s/overlays/prod/ingress.yaml
+++ b/infra/k3s/overlays/prod/ingress.yaml
@@ -1,0 +1,52 @@
+# Single-domain, same-origin path routing (mirrors infra/compose prod):
+#   Host(domain) && (PathPrefix(/api) || Path(/health))  -> api:7330
+#   Host(domain)                                          -> ui:8080  (SPA fallback)
+# One domain, one TLS cert, no CORS. The api route has higher priority so it
+# matches before the ui catch-all. Replace boringstack.example.com everywhere.
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: http-redirect
+  namespace: boringstack-prod
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Host(`boringstack.example.com`)
+      kind: Rule
+      middlewares:
+        - name: redirect-https
+      services:
+        - name: ui
+          port: 8080
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: boringstack
+  namespace: boringstack-prod
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    # API — must precede the UI catch-all.
+    - match: Host(`boringstack.example.com`) && (PathPrefix(`/api`) || Path(`/health`))
+      kind: Rule
+      priority: 10
+      middlewares:
+        - name: security-headers
+        - name: rate-limit
+      services:
+        - name: api
+          port: 7330
+    # UI — host-wide fallback (SPA shell + assets).
+    - match: Host(`boringstack.example.com`)
+      kind: Rule
+      priority: 1
+      middlewares:
+        - name: security-headers
+      services:
+        - name: ui
+          port: 8080
+  tls:
+    secretName: boringstack-tls

--- a/infra/k3s/overlays/prod/kustomization.yaml
+++ b/infra/k3s/overlays/prod/kustomization.yaml
@@ -1,0 +1,85 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# All prod resources land in their own namespace.
+namespace: boringstack-prod
+
+resources:
+  - ../../base
+
+  # --- Secrets backend (pick ONE) ------------------------------------------
+  # Produces the `boringstack-secrets` + `ghcr-registry-secret` Secrets that
+  # the workloads consume. Vault is the default; swap the line for one of the
+  # alternatives in ./secrets/ (see each dir's README).
+  - secrets/vault
+  # - secrets/sealed
+  # - secrets/plain
+
+  # --- Edge: routing, TLS, Traefik middleware ------------------------------
+  - middlewares.yaml
+  - ingress.yaml
+  - certificate.yaml
+
+  # --- Namespace governance ------------------------------------------------
+  - resource-quota.yaml
+  - limitrange.yaml
+
+  # --- Availability --------------------------------------------------------
+  - hpa.yaml
+  - pdbs.yaml
+
+  # --- Error tracking (per-project GlitchTip) ------------------------------
+  - glitchtip
+
+  # --- Monitoring integration (existing cluster kube-prometheus-stack) -----
+  - monitoring
+
+  # --- Postgres backups (opt-in) -------------------------------------------
+  # Requires: secrets/vault/vault-backup-secret (or equivalent) enabled, and
+  # the barman store configured in patches/postgres-backup.yaml. Then
+  # uncomment this line AND the postgres-backup patch below.
+  # - scheduled-backup.yaml
+
+# Image Updater rewrites these tags on every CI build (write-back-target:
+# kustomization). The initial value is a bootstrap placeholder.
+images:
+  - name: ghcr.io/boringstack-xyz/boringstack-api
+    newTag: latest
+  - name: ghcr.io/boringstack-xyz/boringstack-ui
+    newTag: latest
+
+patches:
+  # Pull private GHCR images on every Deployment in the overlay.
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: not-used
+      spec:
+        template:
+          spec:
+            imagePullSecrets:
+              - name: ghcr-registry-secret
+    target:
+      kind: Deployment
+  - path: patches/api-replicas.yaml
+    target:
+      kind: Deployment
+      name: api
+  - path: patches/api-resources.yaml
+    target:
+      kind: Deployment
+      name: api
+  - path: patches/ui-replicas.yaml
+    target:
+      kind: Deployment
+      name: ui
+  - path: patches/postgres-ha.yaml
+    target:
+      kind: Cluster
+      name: boringstack-db
+  # Opt-in barman backup store (enable with scheduled-backup.yaml above):
+  # - path: patches/postgres-backup.yaml
+  #   target:
+  #     kind: Cluster
+  #     name: boringstack-db

--- a/infra/k3s/overlays/prod/limitrange.yaml
+++ b/infra/k3s/overlays/prod/limitrange.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: default-limits
+  namespace: boringstack-prod
+spec:
+  limits:
+    - default:
+        cpu: "500m"
+        memory: "512Mi"
+      defaultRequest:
+        cpu: "100m"
+        memory: "128Mi"
+      type: Container

--- a/infra/k3s/overlays/prod/middlewares.yaml
+++ b/infra/k3s/overlays/prod/middlewares.yaml
@@ -1,0 +1,36 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-https
+  namespace: boringstack-prod
+spec:
+  redirectScheme:
+    scheme: https
+    permanent: true
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: rate-limit
+  namespace: boringstack-prod
+spec:
+  rateLimit:
+    average: 100
+    period: 1m
+    burst: 200
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: security-headers
+  namespace: boringstack-prod
+spec:
+  headers:
+    stsSeconds: 31536000
+    stsIncludeSubdomains: true
+    stsPreload: true
+    forceSTSHeader: true
+    frameDeny: true
+    contentTypeNosniff: true
+    browserXssFilter: true
+    referrerPolicy: strict-origin-when-cross-origin

--- a/infra/k3s/overlays/prod/monitoring/README.md
+++ b/infra/k3s/overlays/prod/monitoring/README.md
@@ -1,0 +1,30 @@
+# Monitoring integration
+
+The k3s target does **not** ship Prometheus/Grafana/Loki. It plugs into the
+cluster's existing [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack):
+
+- **Metrics** — `servicemonitor.yaml` registers the `api` Service so the cluster
+  Prometheus scrapes it. Make sure:
+  1. The ServiceMonitor carries whatever label your Prometheus
+     `serviceMonitorSelector` matches (often `release: <helm-release>`), or the
+     stack is installed with `serviceMonitorSelectorNilUsesHelmValues=false`.
+  2. Prometheus is allowed to discover ServiceMonitors in `boringstack-prod`
+     (its `serviceMonitorNamespaceSelector` must match this namespace).
+
+- **Logs** — Promtail/Alloy in the cluster already scrapes pod stdout by
+  namespace/pod labels; no per-app manifest needed. The pods log to stdout.
+
+- **Dashboards** — the BoringStack Grafana dashboards live in
+  `infra/compose/compose/grafana/dashboards/`. To auto-import them into the
+  cluster Grafana (sidecar discovery), copy the JSON files into
+  `./dashboards/` here and uncomment the `configMapGenerator` in
+  `kustomization.yaml`. The generated ConfigMap is labelled
+  `grafana_dashboard: "1"`, which the Grafana sidecar watches for.
+
+  ```bash
+  mkdir -p dashboards
+  cp ../../../../compose/compose/grafana/dashboards/boringstack-*.json dashboards/
+  ```
+
+  (We don't reference the compose tree directly because ArgoCD/kustomize block
+  path traversal outside the kustomization root by default.)

--- a/infra/k3s/overlays/prod/monitoring/kustomization.yaml
+++ b/infra/k3s/overlays/prod/monitoring/kustomization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Integrates with the cluster's existing kube-prometheus-stack — it does NOT
+# deploy Prometheus/Grafana/Loki. The ServiceMonitor gets the api scraped by
+# the cluster Prometheus. See README.md to also surface the BoringStack Grafana
+# dashboards via the Grafana sidecar.
+resources:
+  - servicemonitor.yaml
+
+# --- Grafana dashboards (optional) ---------------------------------------
+# The BoringStack dashboards live in infra/compose/compose/grafana/dashboards/.
+# To have the cluster Grafana auto-import them, generate a ConfigMap labelled
+# `grafana_dashboard: "1"`. Cross-tree file refs need ArgoCD/kustomize's
+# load-restrictor relaxed, so the simplest portable path is to copy the JSON
+# into ./dashboards/ here and enable the generator below (see README.md).
+#
+# configMapGenerator:
+#   - name: boringstack-grafana-dashboards
+#     files:
+#       - dashboards/boringstack-api.json
+#       - dashboards/boringstack-postgres.json
+#       - dashboards/boringstack-host.json
+#       - dashboards/boringstack-api-logs.json
+#       - dashboards/boringstack-ui-logs.json
+#     options:
+#       labels:
+#         grafana_dashboard: "1"
+#       disableNameSuffixHash: true

--- a/infra/k3s/overlays/prod/monitoring/servicemonitor.yaml
+++ b/infra/k3s/overlays/prod/monitoring/servicemonitor.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: boringstack-api
+  namespace: boringstack-prod
+  labels:
+    app: api
+    # kube-prometheus-stack's Prometheus selects ServiceMonitors by label. Many
+    # installs require the Helm release label (e.g. `release: kube-prometheus-stack`)
+    # OR set serviceMonitorSelectorNilUsesHelmValues=false to pick up all. Add
+    # whatever your cluster's `prometheus.spec.serviceMonitorSelector` matches.
+    # release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app: api
+  endpoints:
+    # Point at the api's Prometheus metrics endpoint. Mirrors the scrape target
+    # in infra/compose/compose/prometheus/prometheus.yml — adjust path/port if
+    # your api exposes metrics elsewhere.
+    - port: http
+      path: /metrics
+      interval: 30s
+      scheme: http

--- a/infra/k3s/overlays/prod/patches/api-replicas.yaml
+++ b/infra/k3s/overlays/prod/patches/api-replicas.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  replicas: 3
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: api
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: api
+                topologyKey: kubernetes.io/hostname

--- a/infra/k3s/overlays/prod/patches/api-resources.yaml
+++ b/infra/k3s/overlays/prod/patches/api-resources.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  template:
+    spec:
+      containers:
+        - name: api
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "2Gi"
+              cpu: "1000m"

--- a/infra/k3s/overlays/prod/patches/postgres-backup.yaml
+++ b/infra/k3s/overlays/prod/patches/postgres-backup.yaml
@@ -1,0 +1,26 @@
+# Opt-in: barman backups to an S3-compatible store (e.g. Cloudflare R2).
+# Enable by: (1) provisioning secrets/vault/vault-backup-secret (or an
+# equivalent `boringstack-backup` Secret with ACCESS_KEY_ID/ACCESS_SECRET_KEY),
+# (2) editing the placeholders below, (3) uncommenting this patch AND
+# scheduled-backup.yaml in ../kustomization.yaml.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: boringstack-db
+spec:
+  postgresql:
+    parameters:
+      archive_mode: "on"
+      archive_timeout: "300"
+  backup:
+    barmanObjectStore:
+      destinationPath: s3://REPLACE_ME_BUCKET/boringstack
+      endpointURL: https://REPLACE_ME_ACCOUNT.r2.cloudflarestorage.com
+      s3Credentials:
+        accessKeyId:
+          name: boringstack-backup
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: boringstack-backup
+          key: ACCESS_SECRET_KEY
+    retentionPolicy: "7d"

--- a/infra/k3s/overlays/prod/patches/postgres-ha.yaml
+++ b/infra/k3s/overlays/prod/patches/postgres-ha.yaml
@@ -1,0 +1,25 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: boringstack-db
+spec:
+  instances: 3
+  storage:
+    size: 50Gi
+  affinity:
+    enablePodAntiAffinity: true
+    topologyKey: kubernetes.io/hostname
+    # `required` needs >= 3 schedulable nodes. Use `preferred` on a smaller
+    # cluster, or scale `instances` down to match.
+    podAntiAffinityType: required
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "250m"
+    limits:
+      memory: "2Gi"
+      cpu: "1000m"
+  postgresql:
+    parameters:
+      shared_buffers: "256MB"
+      max_connections: "100"

--- a/infra/k3s/overlays/prod/patches/ui-replicas.yaml
+++ b/infra/k3s/overlays/prod/patches/ui-replicas.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ui
+spec:
+  replicas: 2
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: ui
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: ui
+                topologyKey: kubernetes.io/hostname

--- a/infra/k3s/overlays/prod/pdbs.yaml
+++ b/infra/k3s/overlays/prod/pdbs.yaml
@@ -1,0 +1,32 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: api-pdb
+  namespace: boringstack-prod
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: api
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: ui-pdb
+  namespace: boringstack-prod
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: ui
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: postgres-pdb
+  namespace: boringstack-prod
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      cnpg.io/cluster: boringstack-db

--- a/infra/k3s/overlays/prod/resource-quota.yaml
+++ b/infra/k3s/overlays/prod/resource-quota.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: boringstack-quota
+  namespace: boringstack-prod
+spec:
+  hard:
+    requests.cpu: "20"
+    requests.memory: 40Gi
+    limits.cpu: "40"
+    limits.memory: 80Gi
+    pods: "50"
+    services: "20"
+    secrets: "50"
+    configmaps: "50"
+    persistentvolumeclaims: "20"

--- a/infra/k3s/overlays/prod/scheduled-backup.yaml
+++ b/infra/k3s/overlays/prod/scheduled-backup.yaml
@@ -1,0 +1,12 @@
+# Opt-in: enable alongside patches/postgres-backup.yaml (see ../kustomization.yaml).
+# CNPG uses 6-field cron (with seconds). This runs every 4 hours.
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: boringstack-db-scheduled
+  namespace: boringstack-prod
+spec:
+  schedule: "0 0 */4 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: boringstack-db

--- a/infra/k3s/overlays/prod/secrets/plain/.gitignore
+++ b/infra/k3s/overlays/prod/secrets/plain/.gitignore
@@ -1,0 +1,2 @@
+# Never commit real secret values.
+secret.env

--- a/infra/k3s/overlays/prod/secrets/plain/README.md
+++ b/infra/k3s/overlays/prod/secrets/plain/README.md
@@ -1,0 +1,24 @@
+# Secrets backend: plain Secret from a gitignored .env
+
+The simplest option — no controller, no Vault. Kustomize's `secretGenerator`
+builds the `boringstack-secrets` Secret from a local `secret.env` that is
+**gitignored** (never committed). Good for a private cluster you apply to
+yourself; less ideal for pure GitOps since the secret values live outside git.
+
+## Use it
+
+1. `cp secret.env.example secret.env` and fill in real values (see the full key
+   list in `infra/k3s/README.md`).
+2. Create the GHCR pull secret out-of-band (it is not env-shaped):
+
+   ```bash
+   kubectl create secret docker-registry ghcr-registry-secret \
+     --namespace boringstack-prod \
+     --docker-server=ghcr.io \
+     --docker-username=<github-user> \
+     --docker-password=<github-pat-read:packages>
+   ```
+
+3. Point the overlay at `secrets/plain` instead of `secrets/vault`.
+
+`secret.env` is matched by `.gitignore` in this directory — keep it that way.

--- a/infra/k3s/overlays/prod/secrets/plain/kustomization.yaml
+++ b/infra/k3s/overlays/prod/secrets/plain/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Plain Secret backend. Reads a gitignored secret.env (see README.md).
+secretGenerator:
+  - name: boringstack-secrets
+    envs:
+      - secret.env
+    options:
+      # Keep the name stable (no content-hash suffix) so the workloads'
+      # static `boringstack-secrets` reference resolves.
+      disableNameSuffixHash: true

--- a/infra/k3s/overlays/prod/secrets/plain/secret.env.example
+++ b/infra/k3s/overlays/prod/secrets/plain/secret.env.example
@@ -1,0 +1,27 @@
+# Copy to secret.env (gitignored) and fill in real values.
+# DATABASE_URL is intentionally absent — CloudNativePG injects it.
+# Full key reference: infra/k3s/README.md.
+
+# --- Core (required) ---
+JWT_SECRET=
+MFA_ENCRYPTION_KEY=
+VALKEY_PASSWORD=
+FRONTEND_URL=https://boringstack.example.com
+PUBLIC_API_URL=https://boringstack.example.com
+
+# --- Operational flags ---
+QUEUES_ENABLED=true
+CACHE_ENABLED=true
+CACHE_PROVIDER=valkey
+
+# --- Email (pick one provider; fill the matching keys) ---
+EMAIL_PROVIDER=
+EMAIL_FROM=noreply@example.com
+
+# --- GlitchTip (per-project error tracking) ---
+GLITCHTIP_SECRET_KEY=
+GLITCHTIP_SUPERUSER_EMAIL=admin@example.com
+GLITCHTIP_SUPERUSER_PASSWORD=
+
+# --- Optional integrations (leave empty to disable) ---
+# OAuth, Stripe, AI, Web Push — see infra/k3s/README.md.

--- a/infra/k3s/overlays/prod/secrets/sealed/README.md
+++ b/infra/k3s/overlays/prod/secrets/sealed/README.md
@@ -1,0 +1,39 @@
+# Secrets backend: Sealed Secrets
+
+GitOps-safe secrets without an external Vault. The Bitnami
+[sealed-secrets](https://github.com/bitnami-labs/sealed-secrets) controller
+decrypts committed `SealedSecret` manifests into real `Secret`s in-cluster.
+
+## Use it
+
+1. Install the controller on the cluster and the `kubeseal` CLI locally.
+2. Author the two Secrets this stack needs, then seal them:
+
+   ```bash
+   # App env -> boringstack-secrets (one key per env var)
+   kubectl create secret generic boringstack-secrets \
+     --namespace boringstack-prod \
+     --from-literal=JWT_SECRET="$(openssl rand -base64 48)" \
+     --from-literal=MFA_ENCRYPTION_KEY="$(openssl rand -base64 32)" \
+     --from-literal=VALKEY_PASSWORD="$(openssl rand -base64 24)" \
+     --from-literal=GLITCHTIP_SECRET_KEY="$(openssl rand -base64 50)" \
+     # ...all other keys from infra/k3s/README.md... \
+     --dry-run=client -o yaml \
+     | kubeseal --format yaml > boringstack-secrets.sealedsecret.yaml
+
+   # GHCR pull creds -> ghcr-registry-secret
+   kubectl create secret docker-registry ghcr-registry-secret \
+     --namespace boringstack-prod \
+     --docker-server=ghcr.io \
+     --docker-username=<github-user> \
+     --docker-password=<github-pat-read:packages> \
+     --dry-run=client -o yaml \
+     | kubeseal --format yaml > ghcr-registry-secret.sealedsecret.yaml
+   ```
+
+3. Commit both `*.sealedsecret.yaml` files here, list them in
+   `kustomization.yaml`, and point the overlay at `secrets/sealed` instead of
+   `secrets/vault`.
+
+SealedSecrets are safe to commit — only the controller's private key can
+decrypt them.

--- a/infra/k3s/overlays/prod/secrets/sealed/kustomization.yaml
+++ b/infra/k3s/overlays/prod/secrets/sealed/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Sealed Secrets backend. Generate the sealed manifests per README.md, commit
+# them here, then list them below and switch the overlay to `secrets/sealed`.
+resources: []
+  # - boringstack-secrets.sealedsecret.yaml
+  # - ghcr-registry-secret.sealedsecret.yaml

--- a/infra/k3s/overlays/prod/secrets/vault/kustomization.yaml
+++ b/infra/k3s/overlays/prod/secrets/vault/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Default secrets backend: HashiCorp Vault via the Vault Secrets Operator.
+# Requires Vault + VSO on the cluster and the KV-v2 paths described in each
+# manifest. The workloads only ever read the resulting k8s Secrets, so this
+# whole directory can be swapped for ../sealed or ../plain.
+resources:
+  - vault-connection.yaml
+  - vault-auth.yaml
+  - vault-secrets.yaml
+  - vault-registry-secret.yaml
+  # Opt-in (Postgres backups):
+  # - vault-backup-secret.yaml

--- a/infra/k3s/overlays/prod/secrets/vault/vault-auth.yaml
+++ b/infra/k3s/overlays/prod/secrets/vault/vault-auth.yaml
@@ -1,0 +1,14 @@
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  name: vault-auth-kubernetes
+spec:
+  method: kubernetes
+  mount: kubernetes
+  kubernetes:
+    # Create this role in Vault, bound to the boringstack-prod namespace's
+    # `default` ServiceAccount. See infra/k3s/README.md for the Vault setup.
+    role: boringstack-prod-role
+    serviceAccount: default
+    tokenExpirationSeconds: 600
+  vaultConnectionRef: vault-connection

--- a/infra/k3s/overlays/prod/secrets/vault/vault-backup-secret.yaml
+++ b/infra/k3s/overlays/prod/secrets/vault/vault-backup-secret.yaml
@@ -1,0 +1,27 @@
+# Opt-in: only needed when Postgres backups (barman -> S3/R2) are enabled.
+# Add this to ./kustomization.yaml's resources, configure patches/postgres-backup.yaml,
+# and enable scheduled-backup.yaml in the overlay.
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: boringstack-backup
+spec:
+  vaultAuthRef: vault-auth-kubernetes
+  mount: secret
+  type: kv-v2
+  # KV-v2 path with AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY for the
+  # S3-compatible backup bucket (e.g. Cloudflare R2).
+  path: boringstack-backup
+  destination:
+    name: boringstack-backup
+    create: true
+    overwrite: true
+    type: Opaque
+    transformation:
+      excludeRaw: true
+      templates:
+        ACCESS_KEY_ID:
+          text: "{{ .Secrets.AWS_ACCESS_KEY_ID }}"
+        ACCESS_SECRET_KEY:
+          text: "{{ .Secrets.AWS_SECRET_ACCESS_KEY }}"
+  hmacSecretData: true

--- a/infra/k3s/overlays/prod/secrets/vault/vault-connection.yaml
+++ b/infra/k3s/overlays/prod/secrets/vault/vault-connection.yaml
@@ -1,0 +1,10 @@
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultConnection
+metadata:
+  name: vault-connection
+spec:
+  # Adjust to your Vault service address. skipTLSVerify is fine for an
+  # in-cluster Vault reached over the pod network; set to false + supply a CA
+  # if you front Vault with TLS.
+  address: http://vault.vault:8200
+  skipTLSVerify: true

--- a/infra/k3s/overlays/prod/secrets/vault/vault-registry-secret.yaml
+++ b/infra/k3s/overlays/prod/secrets/vault/vault-registry-secret.yaml
@@ -1,0 +1,21 @@
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: ghcr-registry-secret
+spec:
+  vaultAuthRef: vault-auth-kubernetes
+  mount: secret
+  type: kv-v2
+  # KV-v2 path holding one key `DOCKER_CONFIG_JSON` — a full Docker
+  # config.json with GHCR credentials (a GitHub PAT with read:packages).
+  path: boringstack-registry
+  destination:
+    name: ghcr-registry-secret
+    create: true
+    overwrite: true
+    type: kubernetes.io/dockerconfigjson
+    transformation:
+      templates:
+        .dockerconfigjson:
+          text: "{{ .Secrets.DOCKER_CONFIG_JSON }}"
+  hmacSecretData: true

--- a/infra/k3s/overlays/prod/secrets/vault/vault-secrets.yaml
+++ b/infra/k3s/overlays/prod/secrets/vault/vault-secrets.yaml
@@ -1,0 +1,19 @@
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: boringstack-secrets
+spec:
+  vaultAuthRef: vault-auth-kubernetes
+  mount: secret
+  type: kv-v2
+  # KV-v2 path holding every app env key (JWT_SECRET, MFA_ENCRYPTION_KEY,
+  # VALKEY_PASSWORD, email/OAuth/Stripe/VAPID keys, GLITCHTIP_* ...). See the
+  # key list in infra/k3s/README.md. DATABASE_URL is NOT here — CNPG injects it.
+  path: boringstack
+  destination:
+    name: boringstack-secrets
+    create: true
+    overwrite: true
+    type: Opaque
+  # Re-sync the k8s Secret (and roll consumers) when the Vault value changes.
+  hmacSecretData: true


### PR DESCRIPTION
## What

Adds **`infra/k3s/`** as a third, opt-in deployment target alongside `infra/compose` (single-host) and `infra/bootstrap` (OpenTofu/Hetzner). It ships BoringStack to any ArgoCD-managed k3s/Kubernetes cluster as GitOps:

> push code → CI builds & pushes GHCR image → `argocd-image-updater` bumps the kustomization tag → ArgoCD syncs.

Modeled on a proven production setup, generalized into a portable, vendor-neutral target.

## What's included

- **`base/`** — namespace, `api` (7330, `/health`+`/ready`), `ui` (nginx static SPA 8080), CloudNativePG Postgres (with a `glitchtip` DB via `postInitSQL`), in-namespace Valkey, NetworkPolicies, RBAC, and an ArgoCD **PreSync migration Job** (`db:migrate && db:seed`).
- **`overlays/prod/`** — single-domain path routing (`/api`→api, catch-all→ui), cert-manager `Certificate`, Traefik middleware, HPAs (api 3–10 / ui 2–5), PDBs, ResourceQuota/LimitRange, HA patches (api×3, ui×2, Postgres×3), **per-project GlitchTip** (web+worker on the shared Postgres/Valkey), and **monitoring integration** with an existing kube-prometheus-stack via `ServiceMonitor` (no duplicate Prom/Grafana/Loki).
- **Swappable secrets component** — `secrets/vault` (default, VSO), `secrets/sealed` (SealedSecrets), `secrets/plain` (gitignored `.env`). Workloads only ever read `boringstack-secrets` / `ghcr-registry-secret`, so swapping is a one-line change.
- **`argocd/`** — the `boringstack-prod` Application with image-updater annotations + an app-of-apps registration example (one of three documented registration options).

## Portability

Kept open-source-friendly and uncoupled from any single cluster: no personal repo URLs/hostnames; storage class, ClusterIssuer, domain, repo, and image-tag strategy are documented knobs. Manifests use the canonical `boringstack*` tokens so `scripts/rename-project.sh` rebrands them.

## Docs

New `infra/kubernetes` page, `topics/provisioning-with-k3s`, three runbooks (ArgoCD image updater, secrets backends, CNPG backups); reframed the "no Kubernetes" note in `infra/overview`; sidebar + `deployment.mdx` cross-links.

## Verification

- `kubectl kustomize` renders **base (18 resources)** and **prod (42)** cleanly; namespace flips to `boringstack-prod`, HA patches apply, PreSync hook + GlitchTip DB + secret wiring correct.
- `grep` confirms **zero** coupling tokens leaked.
- `rename-project.sh --dry-run` covers all **48** rebrandable k3s files.
- Astro docs build passes (**77 pages**, all 5 new pages emitted).
- All three secrets components validated.

## Prerequisites (out of scope here, documented)

- CI must tag GHCR `*-api`/`*-ui` images to match the image-updater regex (same pipeline as the Compose/WUD path).
- Target cluster must have: ArgoCD + image-updater, CloudNativePG, cert-manager (+ DNS-01 issuer), Traefik, a StorageClass, and optionally kube-prometheus-stack + a secrets backend.