### PR TITLE
docs(infra): k3s docs em-dash cleanup + list scoped audit skills

### DIFF
--- a/apps/docs/src/content/docs/infra/kubernetes.mdx
+++ b/apps/docs/src/content/docs/infra/kubernetes.mdx
@@ -3,33 +3,32 @@ title: "Infra template: Kubernetes (k3s)"
 description: Optional GitOps deployment target for any ArgoCD-managed k3s/Kubernetes cluster. Kustomize base + prod overlay, CloudNativePG, Traefik + cert-manager, per-project GlitchTip, swappable secrets.
 ---
 
-`infra/k3s` is the **cluster** deployment target — the alternative to the
-single-host [`infra/compose`](/infra/overview/) and
-[OpenTofu/Hetzner](/topics/provisioning-with-tofu/) paths. Pick the one that
-fits your operating model; you don't need all three.
+`infra/k3s` is the cluster deployment target, the alternative to the single-host
+[`infra/compose`](/infra/overview/) and [OpenTofu/Hetzner](/topics/provisioning-with-tofu/)
+paths. Pick the one that fits your operating model; you don't need all three.
 
-It ships BoringStack to any ArgoCD-managed k3s/Kubernetes cluster as GitOps:
-push code → CI builds & pushes GHCR images → argocd-image-updater bumps the tag
-→ ArgoCD syncs. The whole app runs in one namespace with HA, autoscaling, and
-TLS.
+It ships BoringStack to any ArgoCD-managed k3s/Kubernetes cluster as GitOps: push
+code, CI builds and pushes a GHCR image, argocd-image-updater bumps the tag, and
+ArgoCD syncs. The whole app runs in one namespace with HA, autoscaling, and TLS.
 
 BoringStack is Compose-first on purpose, so this target lives in its own
-`infra/k3s/` subtree and is entirely opt-in — it never sits in the default
-deploy path.
+`infra/k3s/` subtree and is entirely opt-in. It never sits in the default deploy
+path.
 
 ## What runs
 
 | Workload | Manifest | Notes |
 |---|---|---|
-| **api** | `base/api/` | Bun/Elysia, port 7330, `/health` (liveness) + `/ready` (readiness) |
-| **ui** | `base/ui/` | nginx static SPA, port 8080 |
-| **Postgres** | `base/postgres/` | CloudNativePG `Cluster` (1 → 3 instances in prod) |
-| **Valkey** | `base/valkey/` | in-namespace cache + BullMQ backend |
-| **GlitchTip** | `overlays/prod/glitchtip/` | per-project error tracking (web + worker) |
-| **migrations** | `base/api/migration-job.yaml` | ArgoCD PreSync Job: `db:migrate && db:seed` |
+| api | `base/api/` | Bun/Elysia, port 7330, `/health` (liveness) and `/ready` (readiness) |
+| ui | `base/ui/` | nginx static SPA, port 8080 |
+| Postgres | `base/postgres/` | CloudNativePG `Cluster`, 1 instance (3 in prod) |
+| Valkey | `base/valkey/` | in-namespace cache and BullMQ backend |
+| GlitchTip | `overlays/prod/glitchtip/` | per-project error tracking (web and worker) |
+| migrations | `base/api/migration-job.yaml` | ArgoCD PreSync Job: `db:migrate && db:seed` |
 
-Routing mirrors Compose prod — one domain, same-origin path routing:
-`Host && (/api or /health)` → api, everything else → ui (the SPA).
+Routing mirrors Compose prod: one domain with same-origin path routing.
+`Host && (/api or /health)` goes to the api; everything else goes to the ui
+(the SPA).
 
 ## Layout
 
@@ -41,38 +40,37 @@ infra/k3s/
     └── secrets/   swappable backend: vault (default) | sealed | plain
 ```
 
-`base/` is generic; `overlays/prod/` adds replicas/anti-affinity (api ×3, ui ×2,
-Postgres ×3), HPAs, PDBs, a ResourceQuota/LimitRange, Traefik middleware, the
-TLS `Certificate`, GlitchTip, and the monitoring integration.
+`base/` is generic. The prod overlay adds replicas and anti-affinity (api ×3,
+ui ×2, Postgres ×3), HPAs, PDBs, a ResourceQuota/LimitRange, Traefik middleware,
+the TLS `Certificate`, GlitchTip, and the monitoring integration.
 
 ## Prerequisites
 
 The cluster must provide ArgoCD + argocd-image-updater, the CloudNativePG
 operator, cert-manager with a DNS-01 `ClusterIssuer`, Traefik (k3s default), and
 a persistent StorageClass. Optionally kube-prometheus-stack (for the
-ServiceMonitor + Grafana dashboards) and your chosen secrets backend.
+ServiceMonitor and Grafana dashboards) and your chosen secrets backend.
 
 ## Secrets are pluggable
 
-Every workload reads two plain k8s Secrets — `boringstack-secrets` (app env) and
-`ghcr-registry-secret` (GHCR pull) — plus the CNPG-generated `boringstack-db-app`
-(`DATABASE_URL`). The manifests never reference Vault directly, so *how* those
-Secrets are produced is a swappable Kustomize component under
+Every workload reads two plain k8s Secrets, `boringstack-secrets` (app env) and
+`ghcr-registry-secret` (GHCR pull), plus the CNPG-generated `boringstack-db-app`
+that carries `DATABASE_URL`. The manifests never reference Vault directly, so how
+those Secrets are produced is a swappable Kustomize component under
 `overlays/prod/secrets/`:
 
-- **`vault`** (default) — HashiCorp Vault via the Vault Secrets Operator.
-- **`sealed`** — Bitnami SealedSecrets (encrypted, commit-safe).
-- **`plain`** — kustomize `secretGenerator` over a gitignored `secret.env`.
+- `vault` (default): HashiCorp Vault via the Vault Secrets Operator.
+- `sealed`: Bitnami SealedSecrets, encrypted and safe to commit.
+- `plain`: a kustomize `secretGenerator` over a gitignored `secret.env`.
 
 Switch by editing one line in `overlays/prod/kustomization.yaml`. See the
 [secrets backends runbook](/runbooks/vault-secrets-operator/).
 
 ## Monitoring
 
-The target does **not** deploy Prometheus/Grafana/Loki. It plugs into the
-cluster's kube-prometheus-stack via a `ServiceMonitor` (scrapes the api) and
-optional Grafana dashboard ConfigMaps. See
-`overlays/prod/monitoring/README.md`.
+The target does not deploy Prometheus/Grafana/Loki. It plugs into the cluster's
+kube-prometheus-stack via a `ServiceMonitor` that scrapes the api, plus optional
+Grafana dashboard ConfigMaps. See `overlays/prod/monitoring/README.md`.
 
 ## Get started
 
@@ -81,8 +79,8 @@ and `infra/k3s/README.md`.
 
 ## Related
 
-- [Provisioning with k3s](/topics/provisioning-with-k3s/) — zero to live on a cluster.
-- [ArgoCD image updater](/runbooks/argocd-image-updater/) — the auto-deploy loop.
+- [Provisioning with k3s](/topics/provisioning-with-k3s/); zero to live on a cluster.
+- [ArgoCD image updater](/runbooks/argocd-image-updater/); the auto-deploy loop.
 - [Secrets backends (VSO / Sealed / plain)](/runbooks/vault-secrets-operator/).
 - [Postgres backups (CNPG)](/runbooks/cnpg-backups/).
-- [Infra overview](/infra/overview/) — the Compose-first single-host target.
+- [Infra overview](/infra/overview/); the Compose-first single-host target.

--- a/apps/docs/src/content/docs/infra/overview.mdx
+++ b/apps/docs/src/content/docs/infra/overview.mdx
@@ -84,7 +84,7 @@ Every service has `deploy.resources.limits` and `reservations` driven by env var
 
 ## What's not in this template
 
-- Kubernetes manifests in *this* (Compose) target. BoringStack is Compose-first, and `infra/compose` deliberately stays cluster-free so the single-host path is clear. If you run a Kubernetes cluster and want GitOps, the opt-in [Kubernetes (k3s) target](/infra/kubernetes/) lives separately under `infra/k3s` — it never mixes into the Compose flow.
+- Kubernetes manifests in *this* (Compose) target. BoringStack is Compose-first, and `infra/compose` deliberately stays cluster-free so the single-host path is clear. If you run a Kubernetes cluster and want GitOps, the opt-in [Kubernetes (k3s) target](/infra/kubernetes/) lives separately under `infra/k3s`. It never mixes into the Compose flow.
 - Application code. The apps/api and apps/ui own that.
 - Cloud-provider provisioning. The [OpenTofu bootstrap](/topics/provisioning-with-tofu/) in `infra/bootstrap` handles that.
 

--- a/apps/docs/src/content/docs/runbooks/argocd-image-updater.mdx
+++ b/apps/docs/src/content/docs/runbooks/argocd-image-updater.mdx
@@ -1,12 +1,12 @@
 ---
 title: ArgoCD image updater
-description: How the k3s target auto-deploys new builds — image-list, tag strategy, git write-back — and how to bootstrap and troubleshoot it.
+description: How the k3s target auto-deploys new builds via image-list, tag strategy, and git write-back, plus how to bootstrap and troubleshoot it.
 ---
 
 The [k3s target](/infra/kubernetes/) closes the deploy loop with
 [argocd-image-updater](https://argocd-image-updater.readthedocs.io/): when CI
 pushes a new GHCR image, the updater rewrites the tag in
-`overlays/prod/kustomization.yaml` and ArgoCD syncs it. All config is
+`overlays/prod/kustomization.yaml` and ArgoCD syncs it. All config lives in
 annotations on `infra/k3s/argocd/boringstack-prod.yaml`.
 
 ## The annotations
@@ -20,14 +20,16 @@ argocd-image-updater.argoproj.io/write-back-target: kustomization
 argocd-image-updater.argoproj.io/git-branch: main
 ```
 
-- **image-list** — `alias=image` pairs the updater watches.
-- **update-strategy / allow-tags** — `newest-build` + a git-SHA regex assumes CI
-  tags images with the commit SHA. If your CI publishes **semver** instead, use
-  `update-strategy: semver` and an allow-tags like `regexp:^v?\d+\.\d+\.\d+$`.
-- **write-back-method: git** — commits the tag bump back to your repo (GitOps
-  source of truth) using the `argocd/image-updater-git-creds` secret.
-- **write-back-target: kustomization** — edits the `images:` block, not the
-  Application spec.
+`image-list` pairs an alias with each image the updater watches.
+
+`update-strategy` + `allow-tags` of `newest-build` plus a git-SHA regex assumes
+CI tags images with the commit SHA. If your CI publishes semver instead, use
+`update-strategy: semver` and an allow-tags like `regexp:^v?\d+\.\d+\.\d+$`.
+
+`write-back-method: git` commits the tag bump back to your repo (the GitOps
+source of truth) using the `argocd/image-updater-git-creds` secret.
+`write-back-target: kustomization` edits the `images:` block rather than the
+Application spec.
 
 ## Bootstrap
 
@@ -39,19 +41,21 @@ argocd-image-updater.argoproj.io/git-branch: main
      --from-literal=password=<git-PAT-or-deploy-token>
    ```
    (Or an `sshPrivateKey` key for SSH write-back.)
-3. Give it pull access to GHCR (a registry pull secret / `--registries-conf`)
+3. Give it pull access to GHCR (a registry pull secret or `--registries-conf`)
    so it can read tags from your private packages.
 
 ## Troubleshooting
 
-- **No updates happen** — check the image-updater pod logs; confirm the
-  `allow-tags` regex matches the tags CI actually publishes.
-- **Updates detected but not committed** — the git creds secret is missing or
-  lacks push rights to `main`.
-- **Tag bumped but app didn't change** — confirm the Application's `images:`
-  block names match `image-list` exactly (registry + repo path).
+No updates happen: check the image-updater pod logs and confirm the `allow-tags`
+regex matches the tags CI actually publishes.
+
+Updates detected but not committed: the git creds secret is missing or lacks
+push rights to `main`.
+
+Tag bumped but the app didn't change: confirm the Application's `images:` block
+names match `image-list` exactly (registry plus repo path).
 
 ## Related
 
 - [Provisioning with k3s](/topics/provisioning-with-k3s/)
-- [Image updates (Compose / WUD)](/runbooks/image-updates/) — the Compose-path equivalent.
+- [Image updates (Compose / WUD)](/runbooks/image-updates/), the Compose-path equivalent.

--- a/apps/docs/src/content/docs/runbooks/cnpg-backups.mdx
+++ b/apps/docs/src/content/docs/runbooks/cnpg-backups.mdx
@@ -1,31 +1,31 @@
 ---
 title: Postgres backups (CNPG)
-description: Enable CloudNativePG barman backups to S3/R2 for the k3s target — credentials, store config, schedule — and how to restore.
+description: Enable CloudNativePG barman backups to S3/R2 for the k3s target. Credentials, store config, schedule, and restore.
 ---
 
 The [k3s target](/infra/kubernetes/) runs Postgres via the
 [CloudNativePG](https://cloudnative-pg.io/) operator. HA (3 instances) is on by
-default in prod; **off-site backups are opt-in** so the default stack deploys
+default in prod. Off-site backups are opt-in, so the default stack deploys
 without an object store configured.
 
 ## Enable backups
 
-1. **Credentials** — provide an S3-compatible access key as a
-   `boringstack-backup` Secret (keys `ACCESS_KEY_ID` / `ACCESS_SECRET_KEY`). With
-   Vault, uncomment `vault-backup-secret.yaml` in
+1. Credentials. Provide an S3-compatible access key as a `boringstack-backup`
+   Secret (keys `ACCESS_KEY_ID` / `ACCESS_SECRET_KEY`). With Vault, uncomment
+   `vault-backup-secret.yaml` in
    `overlays/prod/secrets/vault/kustomization.yaml` and seed:
    ```bash
    vault kv put secret/boringstack-backup \
      AWS_ACCESS_KEY_ID=<key> AWS_SECRET_ACCESS_KEY=<secret>
    ```
 
-2. **Store** — edit `overlays/prod/patches/postgres-backup.yaml`: set
+2. Store. Edit `overlays/prod/patches/postgres-backup.yaml`: set
    `destinationPath` (e.g. `s3://my-bucket/boringstack`) and `endpointURL` (e.g.
    your Cloudflare R2 endpoint). Adjust `retentionPolicy`.
 
-3. **Wire it up** — in `overlays/prod/kustomization.yaml`, uncomment:
+3. Wire it up. In `overlays/prod/kustomization.yaml`, uncomment:
    - the `scheduled-backup.yaml` resource (runs every 4h via CNPG's 6-field cron)
-   - the `patches/postgres-backup.yaml` patch (attaches the barman store + enables WAL archiving)
+   - the `patches/postgres-backup.yaml` patch (attaches the barman store and enables WAL archiving)
 
 Sync. CNPG starts archiving WAL and taking base backups on schedule.
 
@@ -38,13 +38,13 @@ kubectl -n boringstack-prod get backups
 
 ## Restore
 
-CloudNativePG restores by bootstrapping a **new** Cluster from the object store
-(`bootstrap.recovery`) — you don't restore in place. See the
-[CNPG recovery docs](https://cloudnative-pg.io/documentation/current/recovery/);
-point a recovery `externalCluster` at the same `barmanObjectStore` and the
+CloudNativePG restores by bootstrapping a new Cluster from the object store
+(`bootstrap.recovery`); you don't restore in place. See the
+[CNPG recovery docs](https://cloudnative-pg.io/documentation/current/recovery/),
+then point a recovery `externalCluster` at the same `barmanObjectStore` and the
 `boringstack-backup` credentials.
 
 ## Related
 
 - [Provisioning with k3s](/topics/provisioning-with-k3s/)
-- [Backups (Compose path)](/runbooks/backups/) — the single-host equivalent.
+- [Backups (Compose path)](/runbooks/backups/), the single-host equivalent.

--- a/apps/docs/src/content/docs/runbooks/vault-secrets-operator.mdx
+++ b/apps/docs/src/content/docs/runbooks/vault-secrets-operator.mdx
@@ -1,19 +1,19 @@
 ---
 title: Secrets backends (k3s)
-description: How the k3s target gets secrets into the cluster — the swappable Vault / Sealed Secrets / plain-env component — and how to seed Vault for the default path.
+description: How the k3s target gets secrets into the cluster. The swappable Vault / Sealed Secrets / plain-env component, and how to seed Vault for the default path.
 ---
 
-The [k3s target](/infra/kubernetes/) decouples *what the app reads* from *how
-secrets are stored*. Every workload consumes plain k8s Secrets —
-`boringstack-secrets` (app env) and `ghcr-registry-secret` (GHCR pull) — plus the
-CloudNativePG-generated `boringstack-db-app` (`DATABASE_URL`). The manifests never
-reference Vault directly, so the producer is a swappable Kustomize component in
-`overlays/prod/secrets/`.
+The [k3s target](/infra/kubernetes/) decouples what the app reads from how
+secrets are stored. Every workload consumes plain k8s Secrets,
+`boringstack-secrets` (app env) and `ghcr-registry-secret` (GHCR pull), plus the
+CloudNativePG-generated `boringstack-db-app` that carries `DATABASE_URL`. The
+manifests never reference Vault directly, so the producer is a swappable
+Kustomize component in `overlays/prod/secrets/`.
 
 Switch backends by editing one line under `# Secrets backend (pick ONE)` in
 `overlays/prod/kustomization.yaml`.
 
-## Option A — Vault + Vault Secrets Operator (default)
+## Option A: Vault + Vault Secrets Operator (default)
 
 Requires Vault and the [VSO](https://developer.hashicorp.com/vault/docs/platform/k8s/vso)
 on the cluster. The component ships `VaultConnection`, `VaultAuth`, and
@@ -22,7 +22,7 @@ on the cluster. The component ships `VaultConnection`, `VaultAuth`, and
 Seed Vault (KV-v2 mount `secret`):
 
 ```bash
-# App env — every key the api validates (see infra/k3s/README.md)
+# App env. Every key the api validates (see infra/k3s/README.md)
 vault kv put secret/boringstack \
   JWT_SECRET="$(openssl rand -base64 48)" \
   MFA_ENCRYPTION_KEY="$(openssl rand -base64 32)" \
@@ -32,7 +32,7 @@ vault kv put secret/boringstack \
   QUEUES_ENABLED=true CACHE_PROVIDER=valkey \
   # ...email / OAuth / Stripe / VAPID as needed...
 
-# GHCR pull creds — one key holding a full docker config.json
+# GHCR pull creds. One key holding a full docker config.json
 vault kv put secret/boringstack-registry DOCKER_CONFIG_JSON=@dockerconfig.json
 ```
 
@@ -45,21 +45,21 @@ vault write auth/kubernetes/role/boringstack-prod-role \
   policies=boringstack-read ttl=10m
 ```
 
-## Option B — Sealed Secrets
+## Option B: Sealed Secrets
 
 No external Vault. Encrypt the two Secrets with `kubeseal` and commit the
 `SealedSecret` manifests; the Bitnami controller decrypts them in-cluster. Full
 steps in `overlays/prod/secrets/sealed/README.md`.
 
-## Option C — plain Secret from .env
+## Option C: plain Secret from .env
 
 Simplest. Kustomize's `secretGenerator` builds `boringstack-secrets` from a
 gitignored `secret.env`; create `ghcr-registry-secret` with
 `kubectl create secret docker-registry`. Steps in
 `overlays/prod/secrets/plain/README.md`.
 
-<small>Pure-GitOps note: option C keeps secret values outside git, so it's best
-for a cluster you apply to yourself rather than a fully declarative pipeline.</small>
+A pure-GitOps caveat: option C keeps secret values outside git, so it suits a
+cluster you apply to yourself rather than a fully declarative pipeline.
 
 ## Related
 

--- a/apps/docs/src/content/docs/skills/index.mdx
+++ b/apps/docs/src/content/docs/skills/index.mdx
@@ -43,27 +43,42 @@ On the UI: no raw `fetch` outside `openapi.ts`, no `dangerouslySetInnerHTML`, no
 
 ## Audit skills
 
-Two repo-root skills that pair up for autonomous, agent-to-agent maintenance. The
-audit is machine-readable on purpose: one agent finds the work, another executes it.
+A family of read-only, agent-to-agent audits. Each one runs static analysis and
+writes evidence-backed findings to a single JSON artifact under `.audit/`, which
+`/execute-audit` then works through autonomously. Every finding cites exact files
+and is classified by whether a linter/parser guardrail could enforce it, so fixes
+extend the tooling rather than patch one instance ("lint as a contract").
 
 ### /audit-monorepo
 
-Read-only, full-monorepo audit (apps/api, apps/ui, apps/docs, infra, scripts, CI). Fans
-out parallel read-only subagents per app and concern, then writes a single
-evidence-backed JSON report to `.audit/audit-report.json` — every finding cites exact
-files, ranked for an autonomous agent to execute. Each finding is also classified by
-whether a linter/parser **guardrail** could enforce it, so fixes extend the tooling
-rather than patch one instance ("lint as a contract").
+Read-only, full-monorepo audit (apps/api, apps/ui, apps/docs, infra, scripts, CI,
+root configs). Fans out parallel read-only subagents per app and concern, then
+writes one evidence-backed JSON report to `.audit/audit-report.json`. The broad
+pass when you want everything in one report.
+
+### Scoped audits
+
+Seven focused audits, each staying in its own lane so findings stay precise and
+routable. Reach for one when you want depth in a single area instead of the full
+sweep:
+
+- `/audit-api-security`: apps/api auth, OAuth, and sessions; multi-tenant `accountId` scoping; audit-log coverage on mutations; Stripe webhook verification; cookies; rate limiting; secret/PII leakage.
+- `/audit-drizzle-queries`: the apps/api Drizzle data layer. N+1 patterns, missing indexes, transaction boundaries, query-level `accountId` scoping, raw-SQL safety, pagination correctness.
+- `/audit-react-data`: apps/ui data fetching and forms. TanStack Query keys, caching, and invalidation; mutation and optimistic-update correctness; loading/error states; React Hook Form + Zod validation.
+- `/audit-react-hooks`: apps/ui hooks. Effect dependency arrays, stale closures, memoization and render identity, callback stability, effect cleanup, rules-of-hooks edge cases.
+- `/audit-ci-workflows`: `.github/workflows` and infra pipelines. Action SHA pinning, push/PR path-filter parity, least-privilege permissions, secret handling, concurrency, version-pin drift, local-vs-CI gate parity.
+- `/audit-dependencies`: dependencies across apps. Cross-app version drift, override hygiene, exact-pin policy, lockfile integrity, unused/missing deps (knip), supply-chain and vuln-override posture.
+- `/audit-tests-coverage`: test coverage and quality across apps. Missing sibling tests on logic modules, assertion-light tests, skipped tests without tracking, coverage-ratchet gaps, untested critical paths.
 
 ### /execute-audit
 
 Reads `.audit/audit-report.json` and works every finding to completion on a single
 branch. Guardrail-first: when a finding is a class a rule can catch, it extends the
-relevant `lint:meta` rule so the bug surfaces as a violation, then fixes the code —
-validating each fix with the repo's own `bun run check`, committing per finding, and
-reverting-and-continuing on failure.
+relevant `lint:meta` rule so the bug surfaces as a violation, then fixes the code,
+validating each fix with the repo's own `bun run check`, committing per finding,
+and reverting-and-continuing on failure.
 
 ## Related
 
-- [First feature in 10 minutes](/skills/first-feature-tutorial/)  - end-to-end walkthrough.
-- [Spec loop](/skills/spec-loop/)  - approval gate for risky slices.
+- [First feature in 10 minutes](/skills/first-feature-tutorial/); end-to-end walkthrough.
+- [Spec loop](/skills/spec-loop/); approval gate for risky slices.

--- a/apps/docs/src/content/docs/topics/provisioning-with-k3s.mdx
+++ b/apps/docs/src/content/docs/topics/provisioning-with-k3s.mdx
@@ -7,9 +7,9 @@ import { Aside } from "@astrojs/starlight/components";
 
 The cluster deployment path. Where [OpenTofu](/topics/provisioning-with-tofu/)
 gives you a single VPS running docker-compose, this gives you a GitOps loop on a
-Kubernetes cluster you already run: push code → CI publishes GHCR images →
-argocd-image-updater bumps the tag → ArgoCD syncs. HA, autoscaling, and TLS come
-with it.
+Kubernetes cluster you already run: push code, CI publishes GHCR images,
+argocd-image-updater bumps the tag, and ArgoCD syncs. HA, autoscaling, and TLS
+come with it.
 
 Source lives in [`infra/k3s`](https://github.com/boringstack-xyz/boringstack/tree/main/infra/k3s).
 
@@ -24,18 +24,18 @@ Source lives in [`infra/k3s`](https://github.com/boringstack-xyz/boringstack/tre
 
 A k3s/Kubernetes cluster with these operators installed:
 
-- **ArgoCD** + **argocd-image-updater** (with its `argocd/image-updater-git-creds` write-back secret)
-- **CloudNativePG** operator
-- **cert-manager** + a DNS-01-capable `ClusterIssuer`
-- **Traefik** (ships with k3s) exposing `web` + `websecure` entrypoints
-- a default/persistent **StorageClass**
-- *optional:* **kube-prometheus-stack** (metrics + dashboards), and a secrets
-  backend — **Vault + VSO** (default), or the **SealedSecrets** controller
+- ArgoCD + argocd-image-updater (with its `argocd/image-updater-git-creds` write-back secret)
+- the CloudNativePG operator
+- cert-manager + a DNS-01-capable `ClusterIssuer`
+- Traefik (ships with k3s) exposing `web` + `websecure` entrypoints
+- a default/persistent StorageClass
+- optional: kube-prometheus-stack (metrics and dashboards), and a secrets
+  backend (Vault + VSO by default, or the SealedSecrets controller)
 
 You'll also need CI that builds and pushes `ghcr.io/<owner>/<project>-api` and
-`-ui` images — the same pipeline the Compose/WUD path uses.
+`-ui` images, the same pipeline the Compose/WUD path uses.
 
-## 1. Rebrand & set the knobs
+## 1. Rebrand and set the knobs
 
 From your fork's root:
 
@@ -49,16 +49,16 @@ manifests. Then edit the handful of cluster-specific values (all listed in
 
 - the domain in `overlays/prod/ingress.yaml`, `certificate.yaml`, `glitchtip/`
 - the `ClusterIssuer` name in `overlays/prod/certificate.yaml`
-- the `StorageClass` in `base/postgres/cluster.yaml` + `base/valkey/statefulset.yaml` (optional; defaults to the cluster default)
+- the `StorageClass` in `base/postgres/cluster.yaml` and `base/valkey/statefulset.yaml` (optional; defaults to the cluster default)
 - `source.repoURL` in `argocd/boringstack-prod.yaml`
 
 ## 2. Seed secrets
 
 Pick a backend in `overlays/prod/secrets/` (default Vault). For Vault, populate
-the KV-v2 paths and bind a role — see
+the KV-v2 paths and bind a role, as described in
 [Secrets backends](/runbooks/vault-secrets-operator/). The app's secret keys are
-listed in `infra/k3s/README.md` (`DATABASE_URL` is injected by CloudNativePG, so
-it's not among them).
+listed in `infra/k3s/README.md`. `DATABASE_URL` is injected by CloudNativePG, so
+it isn't among them.
 
 Add your fork to ArgoCD as a repo credential (an SSH deploy key for a private
 repo).
@@ -71,9 +71,9 @@ Either apply the Application directly:
 kubectl apply -f infra/k3s/argocd/boringstack-prod.yaml
 ```
 
-…or, if your cluster is an [app-of-apps](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/),
+Or, if your cluster is an [app-of-apps](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/),
 drop `infra/k3s/argocd/app-of-apps-registration.example.yaml` into your
-app-of-apps repo (it points ArgoCD at your fork's `infra/k3s/argocd` directory).
+app-of-apps repo. It points ArgoCD at your fork's `infra/k3s/argocd` directory.
 
 ## How it works
 
@@ -91,8 +91,8 @@ flowchart LR
 
 ArgoCD renders the prod overlay (base + secrets component + HA patches), runs the
 PreSync migration Job, then rolls out the Deployments. CloudNativePG manages
-Postgres; cert-manager issues the TLS cert; the Vault Secrets Operator (or your
-chosen backend) materializes the app secrets.
+Postgres, cert-manager issues the TLS cert, and the Vault Secrets Operator (or
+your chosen backend) materializes the app secrets.
 
 ## 4. Verify
 
@@ -102,13 +102,14 @@ curl -sI https://<domain>/health                 # 200 from the api
 curl -sI https://<domain>/                        # 200 from the ui (SPA)
 ```
 
-In ArgoCD the Application should be **Synced / Healthy**, and a new commit's
-image should auto-roll within an image-updater poll interval.
+In ArgoCD the Application should be Synced and Healthy, and a new commit's image
+should auto-roll within an image-updater poll interval.
 
-## What stays manual / out of scope
+## What stays manual
 
-- Provisioning the cluster itself — bring your own k3s.
-- In-cluster Prometheus/Grafana/Loki — you integrate with the existing stack.
+Provisioning the cluster itself: bring your own k3s. And in-cluster
+Prometheus/Grafana/Loki, since you integrate with the existing stack rather than
+deploy a second one.
 
 ## Related
 

--- a/infra/k3s/README.md
+++ b/infra/k3s/README.md
@@ -1,17 +1,17 @@
-# infra/k3s — Kubernetes / GitOps deployment target
+# infra/k3s: Kubernetes / GitOps deployment target
 
-A portable, opinionated way to ship BoringStack to **any** ArgoCD-managed
+A portable, opinionated way to ship BoringStack to any ArgoCD-managed
 k3s/Kubernetes cluster. This is the cluster alternative to the single-host
-[`infra/compose`](../compose) and [`infra/bootstrap`](../bootstrap) targets —
-pick the one that fits; you don't need all three.
+[`infra/compose`](../compose) and [`infra/bootstrap`](../bootstrap) targets.
+Pick the one that fits; you don't need all three.
 
-Push code → CI builds & pushes GHCR images → argocd-image-updater bumps the tag
-→ ArgoCD syncs. The full app (api, ui, Postgres, Valkey, GlitchTip) runs in one
+Push code, CI builds and pushes GHCR images, argocd-image-updater bumps the tag,
+and ArgoCD syncs. The full app (api, ui, Postgres, Valkey, GlitchTip) runs in one
 namespace with HA, autoscaling, and TLS.
 
-> This target is **Compose-first BoringStack's** opt-in cluster path. It is kept
-> in its own `infra/k3s/` subtree precisely so it never blurs the simpler
-> Compose deployment flow.
+> This target is Compose-first BoringStack's opt-in cluster path. It is kept in
+> its own `infra/k3s/` subtree precisely so it never blurs the simpler Compose
+> deployment flow.
 
 ## Layout
 
@@ -25,66 +25,65 @@ infra/k3s/
 
 ## Cluster prerequisites
 
-The target cluster must provide (all common, operator-installable):
+The target cluster must provide these (all common, operator-installable):
 
 | Need | Used for |
 |------|----------|
-| ArgoCD + argocd-image-updater | GitOps sync + auto image bumps |
+| ArgoCD + argocd-image-updater | GitOps sync and auto image bumps |
 | CloudNativePG operator | the Postgres `Cluster` |
 | cert-manager + a DNS-01 `ClusterIssuer` | TLS certs |
 | Traefik (k3s default) with `web`/`websecure` entrypoints | ingress |
-| a default/persistent StorageClass | Postgres + Valkey volumes |
-| **(optional)** kube-prometheus-stack | the ServiceMonitor + Grafana dashboards |
-| a secrets backend | Vault+VSO (default), or SealedSecrets controller |
+| a default/persistent StorageClass | Postgres and Valkey volumes |
+| (optional) kube-prometheus-stack | the ServiceMonitor and Grafana dashboards |
+| a secrets backend | Vault+VSO (default), or the SealedSecrets controller |
 
 ## The knobs to edit (per fork)
 
-1. **Rebrand**: `scripts/rename-project.sh <project> <ghcr-owner> <domain>` from
-   the repo root rewrites every `boringstack` / `boringstack-api` /
-   `boringstack-ui` / `boringstack-xyz` token across the repo, including these
-   manifests.
-2. **Domain**: replace `boringstack.example.com` (and
+1. Rebrand. `scripts/rename-project.sh <project> <ghcr-owner> <domain>` from the
+   repo root rewrites every `boringstack` / `boringstack-api` / `boringstack-ui`
+   / `boringstack-xyz` token across the repo, including these manifests.
+2. Domain. Replace `boringstack.example.com` (and
    `glitchtip.boringstack.example.com`) in `overlays/prod/ingress.yaml`,
    `certificate.yaml`, and `glitchtip/`.
-3. **ClusterIssuer**: set `issuerRef.name` in `overlays/prod/certificate.yaml`
-   to your cluster's DNS-01 issuer (`kubectl get clusterissuer`).
-4. **StorageClass**: uncomment/set `storageClass` in `base/postgres/cluster.yaml`
-   and `base/valkey/statefulset.yaml` if you don't want the cluster default.
-5. **Repo URL**: set `source.repoURL` in `argocd/boringstack-prod.yaml` to your
-   fork, and add it to ArgoCD as a repo credential.
-6. **Image tag strategy**: `argocd/boringstack-prod.yaml` assumes CI tags images
-   with the git SHA. If your CI uses semver, switch the `update-strategy` /
+3. ClusterIssuer. Set `issuerRef.name` in `overlays/prod/certificate.yaml` to
+   your cluster's DNS-01 issuer (`kubectl get clusterissuer`).
+4. StorageClass. Uncomment/set `storageClass` in `base/postgres/cluster.yaml` and
+   `base/valkey/statefulset.yaml` if you don't want the cluster default.
+5. Repo URL. Set `source.repoURL` in `argocd/boringstack-prod.yaml` to your fork,
+   and add it to ArgoCD as a repo credential.
+6. Image tag strategy. `argocd/boringstack-prod.yaml` assumes CI tags images with
+   the git SHA. If your CI uses semver, switch the `update-strategy` /
    `allow-tags` annotations.
 
 ## Secrets
 
-Workloads only ever read two k8s Secrets — `boringstack-secrets` (app env) and
-`ghcr-registry-secret` (GHCR pull) — plus the CNPG-generated `boringstack-db-app`
-(DATABASE_URL). *How* those get populated is the swappable component in
+Workloads only ever read two k8s Secrets, `boringstack-secrets` (app env) and
+`ghcr-registry-secret` (GHCR pull), plus the CNPG-generated `boringstack-db-app`
+(`DATABASE_URL`). How those get populated is the swappable component in
 `overlays/prod/secrets/`:
 
-- **`vault`** (default) — Vault + Vault Secrets Operator. Seed KV-v2 paths
+- `vault` (default). Vault + Vault Secrets Operator. Seed KV-v2 paths
   `secret/boringstack`, `secret/boringstack-registry` (and `secret/boringstack-backup`
   for backups), and bind a Vault role `boringstack-prod-role` to the
   `boringstack-prod/default` ServiceAccount.
-- **`sealed`** — Bitnami SealedSecrets (commit encrypted manifests). See its README.
-- **`plain`** — kustomize `secretGenerator` over a gitignored `secret.env`. See its README.
+- `sealed`. Bitnami SealedSecrets (commit encrypted manifests). See its README.
+- `plain`. Kustomize `secretGenerator` over a gitignored `secret.env`. See its README.
 
 Swap by editing the one active line under `# Secrets backend (pick ONE)` in
 `overlays/prod/kustomization.yaml`.
 
 ### App secret keys (`boringstack-secrets`)
 
-`DATABASE_URL` is injected by CNPG — do **not** put it here. Everything else the
-api validates at boot, e.g.:
+`DATABASE_URL` is injected by CNPG, so don't put it here. Everything else the api
+validates at boot, for example:
 
-- **Required**: `JWT_SECRET`, `MFA_ENCRYPTION_KEY`, `VALKEY_PASSWORD`,
+- Required: `JWT_SECRET`, `MFA_ENCRYPTION_KEY`, `VALKEY_PASSWORD`,
   `FRONTEND_URL`, `PUBLIC_API_URL`, `QUEUES_ENABLED=true`, `CACHE_PROVIDER=valkey`
-- **Email** (one provider): `EMAIL_PROVIDER`, `EMAIL_FROM`, + provider keys
+- Email (one provider): `EMAIL_PROVIDER`, `EMAIL_FROM`, plus provider keys
   (`RESEND_API_KEY` / `SENDGRID_API_KEY` / `SMTP_*` / Cloudflare)
-- **GlitchTip**: `GLITCHTIP_SECRET_KEY`, `GLITCHTIP_SUPERUSER_EMAIL`,
+- GlitchTip: `GLITCHTIP_SECRET_KEY`, `GLITCHTIP_SUPERUSER_EMAIL`,
   `GLITCHTIP_SUPERUSER_PASSWORD`, optional `GLITCHTIP_EMAIL_URL`
-- **Optional**: OAuth (`*_OAUTH_CLIENT_ID/SECRET`), Stripe (`STRIPE_*`),
+- Optional: OAuth (`*_OAUTH_CLIENT_ID/SECRET`), Stripe (`STRIPE_*`),
   Web Push (`WEB_PUSH_VAPID_*`), AI (`AI_*`, `OPENAI_API_KEY`, …)
 
 `VALKEY_PASSWORD` is shared: the api, GlitchTip, and the Valkey StatefulSet's
@@ -92,14 +91,14 @@ api validates at boot, e.g.:
 
 ## Deploy
 
-1. Rebrand + edit the knobs above.
-2. Ensure CI builds & pushes `ghcr.io/<owner>/<project>-api` and `-ui` (the UI
-   build must pass the `VITE_*` build args — `VITE_API_URL` empty for
-   same-origin, `VITE_SENTRY_DSN` = your GlitchTip DSN). This is the same image
-   pipeline the Compose/WUD path uses.
+1. Rebrand and edit the knobs above.
+2. Ensure CI builds and pushes `ghcr.io/<owner>/<project>-api` and `-ui`. The UI
+   build must pass the `VITE_*` build args (`VITE_API_URL` empty for same-origin,
+   `VITE_SENTRY_DSN` set to your GlitchTip DSN). This is the same image pipeline
+   the Compose/WUD path uses.
 3. Populate secrets via your chosen backend.
-4. Register with ArgoCD — either:
-   - `kubectl apply -f infra/k3s/argocd/boringstack-prod.yaml`, **or**
+4. Register with ArgoCD, either:
+   - `kubectl apply -f infra/k3s/argocd/boringstack-prod.yaml`, or
    - add `argocd/app-of-apps-registration.example.yaml` to your app-of-apps repo.
 5. ArgoCD runs the PreSync migration Job (`db:migrate && db:seed`), then rolls
    out the deployments. Watch it reach Healthy.
@@ -108,17 +107,17 @@ api validates at boot, e.g.:
 
 ```bash
 # Structural render (no cluster needed)
-kustomize build infra/k3s/overlays/prod | head
+kubectl kustomize infra/k3s/overlays/prod | head
 
 # Live
 kubectl -n boringstack-prod get pods
-curl -sI https://<domain>/health        # -> 200 from the api
-curl -sI https://<domain>/              # -> 200 from the ui (SPA)
+curl -sI https://<domain>/health        # 200 from the api
+curl -sI https://<domain>/              # 200 from the ui (SPA)
 ```
 
 ## What's intentionally not here
 
-- In-cluster Prometheus/Grafana/Loki — integrate with the cluster's stack
+- In-cluster Prometheus/Grafana/Loki. Integrate with the cluster's stack
   (`overlays/prod/monitoring/`).
-- Provisioning the cluster itself — bring your own k3s.
-- App code — that's `apps/api` and `apps/ui`.
+- Provisioning the cluster itself. Bring your own k3s.
+- App code. That's `apps/api` and `apps/ui`.

--- a/infra/k3s/argocd/app-of-apps-registration.example.yaml
+++ b/infra/k3s/argocd/app-of-apps-registration.example.yaml
@@ -1,4 +1,4 @@
-# OPTIONAL — only if your cluster is managed by an ArgoCD "app-of-apps".
+# OPTIONAL, only if your cluster is managed by an ArgoCD "app-of-apps".
 #
 # Most clusters can skip this: just `kubectl apply -f boringstack-prod.yaml`
 # (the file next to this one) to register the product directly.

--- a/infra/k3s/base/api/deployment.yaml
+++ b/infra/k3s/base/api/deployment.yaml
@@ -43,8 +43,8 @@ spec:
               protocol: TCP
           # All app secrets/config arrive as one Secret (`boringstack-secrets`),
           # produced by the chosen secrets component in overlays/prod/secrets/*.
-          # The manifests never reference Vault directly — only this Secret —
-          # so Vault / Sealed Secrets / plain-env swap with a one-line change.
+          # The manifests never reference Vault directly, only this Secret, so
+          # Vault / Sealed Secrets / plain-env swap with a one-line change.
           envFrom:
             - secretRef:
                 name: boringstack-secrets
@@ -64,7 +64,7 @@ spec:
               value: "7330"
             - name: NODE_ENV
               value: production
-            # Behind Traefik — read X-Forwarded-* for correct client IPs.
+            # Behind Traefik, read X-Forwarded-* for correct client IPs.
             - name: TRUST_PROXY
               value: "true"
           # /health is a cheap liveness check; /ready aggregates db + valkey +

--- a/infra/k3s/base/postgres/cluster.yaml
+++ b/infra/k3s/base/postgres/cluster.yaml
@@ -7,7 +7,7 @@ spec:
   instances: 1
   storage:
     size: 10Gi
-    # Storage class is a per-cluster knob — see infra/k3s/README.md. Leave the
+    # Storage class is a per-cluster knob, see infra/k3s/README.md. Leave the
     # line commented to use the cluster default, or set e.g. `longhorn`.
     # storageClass: longhorn
   postgresql:

--- a/infra/k3s/base/ui/networkpolicy.yaml
+++ b/infra/k3s/base/ui/networkpolicy.yaml
@@ -11,7 +11,7 @@ spec:
     - Ingress
     - Egress
   ingress:
-    # From the Traefik ingress controller only — the SPA is served to browsers.
+    # From the Traefik ingress controller only, the SPA is served to browsers.
     - from:
         - namespaceSelector:
             matchLabels:

--- a/infra/k3s/base/valkey/statefulset.yaml
+++ b/infra/k3s/base/valkey/statefulset.yaml
@@ -89,7 +89,7 @@ spec:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
-        # Storage class is a per-cluster knob — see infra/k3s/README.md.
+        # Storage class is a per-cluster knob, see infra/k3s/README.md.
         # Leave unset to use the cluster default, or set e.g. `longhorn`.
         # storageClassName: longhorn
         resources:

--- a/infra/k3s/overlays/prod/certificate.yaml
+++ b/infra/k3s/overlays/prod/certificate.yaml
@@ -2,7 +2,7 @@
 # Prerequisites:
 #   - cert-manager installed in the cluster
 #   - a DNS-01-capable ClusterIssuer (verify name: kubectl get clusterissuer)
-# The issuer name below is a per-cluster knob — see infra/k3s/README.md.
+# The issuer name below is a per-cluster knob, see infra/k3s/README.md.
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/infra/k3s/overlays/prod/ingress.yaml
+++ b/infra/k3s/overlays/prod/ingress.yaml
@@ -29,7 +29,7 @@ spec:
   entryPoints:
     - websecure
   routes:
-    # API — must precede the UI catch-all.
+    # API, must precede the UI catch-all.
     - match: Host(`boringstack.example.com`) && (PathPrefix(`/api`) || Path(`/health`))
       kind: Rule
       priority: 10
@@ -39,7 +39,7 @@ spec:
       services:
         - name: api
           port: 7330
-    # UI — host-wide fallback (SPA shell + assets).
+    # UI, host-wide fallback (SPA shell + assets).
     - match: Host(`boringstack.example.com`)
       kind: Rule
       priority: 1

--- a/infra/k3s/overlays/prod/monitoring/README.md
+++ b/infra/k3s/overlays/prod/monitoring/README.md
@@ -3,7 +3,7 @@
 The k3s target does **not** ship Prometheus/Grafana/Loki. It plugs into the
 cluster's existing [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack):
 
-- **Metrics** — `servicemonitor.yaml` registers the `api` Service so the cluster
+- Metrics. `servicemonitor.yaml` registers the `api` Service so the cluster
   Prometheus scrapes it. Make sure:
   1. The ServiceMonitor carries whatever label your Prometheus
      `serviceMonitorSelector` matches (often `release: <helm-release>`), or the
@@ -11,10 +11,10 @@ cluster's existing [kube-prometheus-stack](https://github.com/prometheus-communi
   2. Prometheus is allowed to discover ServiceMonitors in `boringstack-prod`
      (its `serviceMonitorNamespaceSelector` must match this namespace).
 
-- **Logs** — Promtail/Alloy in the cluster already scrapes pod stdout by
+- Logs. Promtail/Alloy in the cluster already scrapes pod stdout by
   namespace/pod labels; no per-app manifest needed. The pods log to stdout.
 
-- **Dashboards** — the BoringStack Grafana dashboards live in
+- Dashboards. The BoringStack Grafana dashboards live in
   `infra/compose/compose/grafana/dashboards/`. To auto-import them into the
   cluster Grafana (sidecar discovery), copy the JSON files into
   `./dashboards/` here and uncomment the `configMapGenerator` in

--- a/infra/k3s/overlays/prod/monitoring/kustomization.yaml
+++ b/infra/k3s/overlays/prod/monitoring/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# Integrates with the cluster's existing kube-prometheus-stack — it does NOT
+# Integrates with the cluster's existing kube-prometheus-stack, it does NOT
 # deploy Prometheus/Grafana/Loki. The ServiceMonitor gets the api scraped by
 # the cluster Prometheus. See README.md to also surface the BoringStack Grafana
 # dashboards via the Grafana sidecar.

--- a/infra/k3s/overlays/prod/monitoring/servicemonitor.yaml
+++ b/infra/k3s/overlays/prod/monitoring/servicemonitor.yaml
@@ -16,7 +16,7 @@ spec:
       app: api
   endpoints:
     # Point at the api's Prometheus metrics endpoint. Mirrors the scrape target
-    # in infra/compose/compose/prometheus/prometheus.yml — adjust path/port if
+    # in infra/compose/compose/prometheus/prometheus.yml, adjust path/port if
     # your api exposes metrics elsewhere.
     - port: http
       path: /metrics

--- a/infra/k3s/overlays/prod/secrets/plain/README.md
+++ b/infra/k3s/overlays/prod/secrets/plain/README.md
@@ -1,9 +1,10 @@
 # Secrets backend: plain Secret from a gitignored .env
 
-The simplest option — no controller, no Vault. Kustomize's `secretGenerator`
-builds the `boringstack-secrets` Secret from a local `secret.env` that is
-**gitignored** (never committed). Good for a private cluster you apply to
-yourself; less ideal for pure GitOps since the secret values live outside git.
+The simplest option, with no controller and no Vault. Kustomize's
+`secretGenerator` builds the `boringstack-secrets` Secret from a local
+`secret.env` that is gitignored (never committed). Good for a private cluster you
+apply to yourself; less ideal for pure GitOps since the secret values live
+outside git.
 
 ## Use it
 
@@ -21,4 +22,4 @@ yourself; less ideal for pure GitOps since the secret values live outside git.
 
 3. Point the overlay at `secrets/plain` instead of `secrets/vault`.
 
-`secret.env` is matched by `.gitignore` in this directory — keep it that way.
+`secret.env` is matched by `.gitignore` in this directory; keep it that way.

--- a/infra/k3s/overlays/prod/secrets/plain/secret.env.example
+++ b/infra/k3s/overlays/prod/secrets/plain/secret.env.example
@@ -1,5 +1,5 @@
 # Copy to secret.env (gitignored) and fill in real values.
-# DATABASE_URL is intentionally absent — CloudNativePG injects it.
+# DATABASE_URL is intentionally absent, CloudNativePG injects it.
 # Full key reference: infra/k3s/README.md.
 
 # --- Core (required) ---
@@ -24,4 +24,4 @@ GLITCHTIP_SUPERUSER_EMAIL=admin@example.com
 GLITCHTIP_SUPERUSER_PASSWORD=
 
 # --- Optional integrations (leave empty to disable) ---
-# OAuth, Stripe, AI, Web Push — see infra/k3s/README.md.
+# OAuth, Stripe, AI, Web Push, see infra/k3s/README.md.

--- a/infra/k3s/overlays/prod/secrets/sealed/README.md
+++ b/infra/k3s/overlays/prod/secrets/sealed/README.md
@@ -35,5 +35,5 @@ decrypts committed `SealedSecret` manifests into real `Secret`s in-cluster.
    `kustomization.yaml`, and point the overlay at `secrets/sealed` instead of
    `secrets/vault`.
 
-SealedSecrets are safe to commit — only the controller's private key can
+SealedSecrets are safe to commit; only the controller's private key can
 decrypt them.

--- a/infra/k3s/overlays/prod/secrets/vault/vault-registry-secret.yaml
+++ b/infra/k3s/overlays/prod/secrets/vault/vault-registry-secret.yaml
@@ -6,7 +6,7 @@ spec:
   vaultAuthRef: vault-auth-kubernetes
   mount: secret
   type: kv-v2
-  # KV-v2 path holding one key `DOCKER_CONFIG_JSON` — a full Docker
+  # KV-v2 path holding one key `DOCKER_CONFIG_JSON`, a full Docker
   # config.json with GHCR credentials (a GitHub PAT with read:packages).
   path: boringstack-registry
   destination:

--- a/infra/k3s/overlays/prod/secrets/vault/vault-secrets.yaml
+++ b/infra/k3s/overlays/prod/secrets/vault/vault-secrets.yaml
@@ -8,7 +8,7 @@ spec:
   type: kv-v2
   # KV-v2 path holding every app env key (JWT_SECRET, MFA_ENCRYPTION_KEY,
   # VALKEY_PASSWORD, email/OAuth/Stripe/VAPID keys, GLITCHTIP_* ...). See the
-  # key list in infra/k3s/README.md. DATABASE_URL is NOT here — CNPG injects it.
+  # key list in infra/k3s/README.md. DATABASE_URL is NOT here, CNPG injects it.
   path: boringstack
   destination:
     name: boringstack-secrets


### PR DESCRIPTION
Follow-up to #163, which squash-merged before these two doc commits were pushed, so they didn't land on `main`. This PR carries exactly that missing delta. No manifest behavior changes.

## 1. Drop em dashes and AI-isms from the k3s docs

The k3s docs (added in #163) shipped with ~59 em dashes across prose, headings, frontmatter `description` lines, and YAML comments. This rewrites them to the repo's plain style: `X — Y` separators become commas/colons/periods, "Related" lists use the existing `](url); description` convention, and a few bolded inline labels are trimmed. Verified zero em dashes remain across the touched files.

## 2. List the 7 scoped audit skills on `/skills/`

The skills page documented only `audit-monorepo` and `execute-audit`. The seven scoped per-domain audits added in #162 were missing. Adds a **Scoped audits** subsection with an accurate one-liner per skill (drawn from each skill's own `description`):

- `audit-api-security`, `audit-drizzle-queries`, `audit-react-data`, `audit-react-hooks`, `audit-ci-workflows`, `audit-dependencies`, `audit-tests-coverage`

Reconciliation confirms all 15 `.claude` skills are now documented.

## Verify

- `kubectl kustomize infra/k3s/overlays/prod` renders 42 resources.
- Astro docs build passes (77 pages).
- UTF-8 sweep: zero em dashes in the changed files.