### PR TITLE
fix(infra): correct k3s image-updater tag regex + add validate CI

### DIFF
--- a/.github/workflows/infra-k3s-validate.yml
+++ b/.github/workflows/infra-k3s-validate.yml
@@ -1,0 +1,61 @@
+name: validate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: infra-k3s-validate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: kustomize build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Detect relevant changes
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'infra/k3s/**'
+              - '.github/workflows/infra-k3s-validate.yml'
+
+      - name: Install kubectl (bundles kustomize)
+        if: steps.filter.outputs.code == 'true'
+        uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede # v4.0.1
+
+      # `kubectl kustomize` renders base + prod overlay offline. Catches the
+      # realistic breakage: bad resource refs, malformed YAML, broken patches,
+      # and the swappable secrets component wiring. CRDs (CNPG, Traefik,
+      # cert-manager, VSO, ServiceMonitor) need no schema here; render is enough.
+      - name: Build base
+        if: steps.filter.outputs.code == 'true'
+        run: kubectl kustomize infra/k3s/base > /dev/null
+
+      - name: Build prod overlay
+        if: steps.filter.outputs.code == 'true'
+        run: kubectl kustomize infra/k3s/overlays/prod > /dev/null
+
+      # The alternative secrets backends must also stay renderable. `plain`
+      # needs a secret.env (gitignored), so seed a throwaway one for the check.
+      - name: Build sealed secrets component
+        if: steps.filter.outputs.code == 'true'
+        run: kubectl kustomize infra/k3s/overlays/prod/secrets/sealed > /dev/null
+
+      - name: Build plain secrets component
+        if: steps.filter.outputs.code == 'true'
+        run: |
+          set -euo pipefail
+          printf 'JWT_SECRET=x\nVALKEY_PASSWORD=x\n' > infra/k3s/overlays/prod/secrets/plain/secret.env
+          trap 'rm -f infra/k3s/overlays/prod/secrets/plain/secret.env' EXIT
+          kubectl kustomize infra/k3s/overlays/prod/secrets/plain > /dev/null

--- a/apps/docs/src/content/docs/runbooks/argocd-image-updater.mdx
+++ b/apps/docs/src/content/docs/runbooks/argocd-image-updater.mdx
@@ -14,7 +14,7 @@ annotations on `infra/k3s/argocd/boringstack-prod.yaml`.
 ```yaml
 argocd-image-updater.argoproj.io/image-list: api=ghcr.io/<owner>/<project>-api, ui=ghcr.io/<owner>/<project>-ui
 argocd-image-updater.argoproj.io/api.update-strategy: newest-build
-argocd-image-updater.argoproj.io/api.allow-tags: regexp:^[a-f0-9]{7,40}$
+argocd-image-updater.argoproj.io/api.allow-tags: regexp:^sha-[0-9a-f]{7,40}$
 argocd-image-updater.argoproj.io/write-back-method: git:secret:argocd/image-updater-git-creds
 argocd-image-updater.argoproj.io/write-back-target: kustomization
 argocd-image-updater.argoproj.io/git-branch: main
@@ -22,9 +22,11 @@ argocd-image-updater.argoproj.io/git-branch: main
 
 `image-list` pairs an alias with each image the updater watches.
 
-`update-strategy` + `allow-tags` of `newest-build` plus a git-SHA regex assumes
-CI tags images with the commit SHA. If your CI publishes semver instead, use
-`update-strategy: semver` and an allow-tags like `regexp:^v?\d+\.\d+\.\d+$`.
+`update-strategy: newest-build` plus the `^sha-` regex tracks the newest
+`sha-<short>` build. BoringStack's release workflows tag every push to main as
+`latest` + `sha-<short>` (and a semver tag on a `v*` release), so this matches
+the `sha-` form and ignores `latest`. To deploy only tagged releases instead,
+use `update-strategy: semver` with `allow-tags: regexp:^v?\d+\.\d+\.\d+$`.
 
 `write-back-method: git` commits the tag bump back to your repo (the GitOps
 source of truth) using the `argocd/image-updater-git-creds` secret.

--- a/apps/docs/src/content/docs/runbooks/vault-secrets-operator.mdx
+++ b/apps/docs/src/content/docs/runbooks/vault-secrets-operator.mdx
@@ -22,7 +22,8 @@ on the cluster. The component ships `VaultConnection`, `VaultAuth`, and
 Seed Vault (KV-v2 mount `secret`):
 
 ```bash
-# App env. Every key the api validates (see infra/k3s/README.md)
+# App env. Full key list: the api env validator, documented at
+# /reference/env-vars/. DATABASE_URL is injected by CNPG, so it's not here.
 vault kv put secret/boringstack \
   JWT_SECRET="$(openssl rand -base64 48)" \
   MFA_ENCRYPTION_KEY="$(openssl rand -base64 32)" \

--- a/apps/docs/src/content/docs/topics/deployment.mdx
+++ b/apps/docs/src/content/docs/topics/deployment.mdx
@@ -17,6 +17,18 @@ About thirty minutes of hands-on time on the first run.
   [Provisioning with k3s](/topics/provisioning-with-k3s/).
 </Aside>
 
+## Choosing a target
+
+BoringStack ships three deploy paths. Pick one; you don't need all three.
+
+| Target | Best for | Guide |
+|---|---|---|
+| docker-compose on a VPS (manual) | First deploy, one box, full hands-on control | This page |
+| OpenTofu → Hetzner | One declarative apply that provisions and boots that same box | [Provisioning with OpenTofu](/topics/provisioning-with-tofu/) |
+| k3s + ArgoCD (GitOps) | You already run a cluster and want push-to-deploy with HA | [Provisioning with k3s](/topics/provisioning-with-k3s/) |
+
+The rest of this page is the manual docker-compose path.
+
 ## 1. Accounts
 
 | Account | Why |

--- a/apps/docs/src/content/docs/topics/provisioning-with-k3s.mdx
+++ b/apps/docs/src/content/docs/topics/provisioning-with-k3s.mdx
@@ -105,6 +105,18 @@ curl -sI https://<domain>/                        # 200 from the ui (SPA)
 In ArgoCD the Application should be Synced and Healthy, and a new commit's image
 should auto-roll within an image-updater poll interval.
 
+### First-deploy checks
+
+Two things only the first apply confirms on your cluster:
+
+- GlitchTip migrates its schema and seeds the superuser on first boot from the
+  `GLITCHTIP_*` env, rather than from a separate Job. Watch the `glitchtip-web`
+  pod reach Ready, then log in once at `glitchtip.<domain>`.
+- The `glitchtip` database is created by the CloudNativePG cluster's
+  `postInitSQL`, which runs only at initial bootstrap. If you point GlitchTip at
+  an already-initialized cluster, create the database manually
+  (`CREATE DATABASE glitchtip OWNER boringstack;`).
+
 ## What stays manual
 
 Provisioning the cluster itself: bring your own k3s. And in-cluster

--- a/infra/k3s/README.md
+++ b/infra/k3s/README.md
@@ -74,20 +74,19 @@ Swap by editing the one active line under `# Secrets backend (pick ONE)` in
 
 ### App secret keys (`boringstack-secrets`)
 
-`DATABASE_URL` is injected by CNPG, so don't put it here. Everything else the api
-validates at boot, for example:
+The authoritative key list is the api's env validator, documented on the
+[Environment variables](https://boringstack.xyz/reference/env-vars/) reference.
+Populate from there rather than copying a list that drifts. The k3s-specific
+points:
 
-- Required: `JWT_SECRET`, `MFA_ENCRYPTION_KEY`, `VALKEY_PASSWORD`,
-  `FRONTEND_URL`, `PUBLIC_API_URL`, `QUEUES_ENABLED=true`, `CACHE_PROVIDER=valkey`
-- Email (one provider): `EMAIL_PROVIDER`, `EMAIL_FROM`, plus provider keys
-  (`RESEND_API_KEY` / `SENDGRID_API_KEY` / `SMTP_*` / Cloudflare)
-- GlitchTip: `GLITCHTIP_SECRET_KEY`, `GLITCHTIP_SUPERUSER_EMAIL`,
-  `GLITCHTIP_SUPERUSER_PASSWORD`, optional `GLITCHTIP_EMAIL_URL`
-- Optional: OAuth (`*_OAUTH_CLIENT_ID/SECRET`), Stripe (`STRIPE_*`),
-  Web Push (`WEB_PUSH_VAPID_*`), AI (`AI_*`, `OPENAI_API_KEY`, …)
-
-`VALKEY_PASSWORD` is shared: the api, GlitchTip, and the Valkey StatefulSet's
-`--requirepass` all read it.
+- `DATABASE_URL` is injected by CloudNativePG, so it is NOT a key here.
+- `VALKEY_PASSWORD` is shared: the api, GlitchTip, and the Valkey StatefulSet's
+  `--requirepass` all read it.
+- The GlitchTip overlay needs `GLITCHTIP_SECRET_KEY` plus `GLITCHTIP_SUPERUSER_EMAIL`
+  / `GLITCHTIP_SUPERUSER_PASSWORD` (and optional `GLITCHTIP_EMAIL_URL`).
+- Enough to boot: `JWT_SECRET`, `MFA_ENCRYPTION_KEY`, `VALKEY_PASSWORD`,
+  `FRONTEND_URL`, `PUBLIC_API_URL`, `QUEUES_ENABLED=true`, `CACHE_PROVIDER=valkey`.
+  Email, OAuth, Stripe, Web Push, and AI keys follow the reference.
 
 ## Deploy
 

--- a/infra/k3s/argocd/boringstack-prod.yaml
+++ b/infra/k3s/argocd/boringstack-prod.yaml
@@ -8,13 +8,15 @@ metadata:
     # alias=full-image-path. The updater watches GHCR and writes the new tag
     # back into overlays/prod/kustomization.yaml, which triggers a sync.
     argocd-image-updater.argoproj.io/image-list: api=ghcr.io/boringstack-xyz/boringstack-api, ui=ghcr.io/boringstack-xyz/boringstack-ui
-    # Track newest git-SHA tag (matches a CI that tags images with the commit
-    # SHA). If your CI publishes semver instead, switch to `semver` and set
-    # allow-tags accordingly.
+    # Track the newest `sha-<short>` build. BoringStack's release workflows tag
+    # every push to main as `latest` + `sha-<short>` (and a semver tag on a
+    # changesets/`v*` release), so allow-tags matches the sha- form and ignores
+    # `latest`. To pin to releases instead, switch to `update-strategy: semver`
+    # with `allow-tags: regexp:^v?\d+\.\d+\.\d+$`.
     argocd-image-updater.argoproj.io/api.update-strategy: newest-build
-    argocd-image-updater.argoproj.io/api.allow-tags: regexp:^[a-f0-9]{7,40}$
+    argocd-image-updater.argoproj.io/api.allow-tags: regexp:^sha-[0-9a-f]{7,40}$
     argocd-image-updater.argoproj.io/ui.update-strategy: newest-build
-    argocd-image-updater.argoproj.io/ui.allow-tags: regexp:^[a-f0-9]{7,40}$
+    argocd-image-updater.argoproj.io/ui.allow-tags: regexp:^sha-[0-9a-f]{7,40}$
     # Commit the tag bump back to git (GitOps source of truth).
     argocd-image-updater.argoproj.io/write-back-method: git:secret:argocd/image-updater-git-creds
     argocd-image-updater.argoproj.io/write-back-target: kustomization


### PR DESCRIPTION
Follow-up to the merged #163/#164. Carries work that was pushed after #164 already merged, so it never landed on `main`.

## fix: image-updater would never auto-deploy (bug)

The k3s Application's `allow-tags` was `^[a-f0-9]{7,40}$`, but the release workflows tag images `sha-<short>` (plus `latest` and semver). The regex matched none of those, so `newest-build` would find no tags and the GitOps loop would silently never fire. Corrected to `^sha-[0-9a-f]{7,40}$` in `boringstack-prod.yaml` and the `argocd-image-updater` runbook, with the real tag scheme documented.

## ci: add `infra-k3s-validate.yml`

Mirrors `infra-bootstrap-validate` / `infra-compose-validate-compose`: push + PR triggers, `contents: read`, SHA-pinned actions, in-job `dorny/paths-filter` gate. Renders `base`, the `prod` overlay, and both alternate secrets components via `kubectl kustomize`. `actionlint` clean.

## docs clarity

- Stop duplicating the app secret-key list; point to the [Environment variables](https://boringstack.xyz/reference/env-vars/) reference and keep only the k3s-specific notes (CNPG-injected `DATABASE_URL`, shared `VALKEY_PASSWORD`, GlitchTip keys).
- Add a "Choosing a target" table (compose vs OpenTofu vs k3s) to the deployment guide.
- Note the two first-deploy checks: GlitchTip auto-migrates on boot, and the `glitchtip` DB comes from CNPG `postInitSQL` (bootstrap-only).

## Verify
- `kubectl kustomize` renders base + prod + both secrets components.
- `actionlint` clean; new workflow self-validates on this PR.
- Docs build passes (77 pages); zero em dashes in touched files.