### PR TITLE
feat(infra): OpenTofu 1.12 + defense-in-depth VPS protection

### DIFF
--- a/.github/workflows/infra-bootstrap-validate.yml
+++ b/.github/workflows/infra-bootstrap-validate.yml
@@ -37,6 +37,7 @@ jobs:
         if: steps.filter.outputs.code == 'true'
         uses: opentofu/setup-opentofu@847eaa4afeb791b06daa46e8eafa8b1b68d7cfb4 # v2.0.1
         with:
+          tofu_version: "1.12.0"
           tofu_wrapper: false
 
       - name: Check formatting

--- a/infra/bootstrap/.terraform.lock.hcl
+++ b/infra/bootstrap/.terraform.lock.hcl
@@ -6,6 +6,13 @@ provider "registry.opentofu.org/cloudflare/cloudflare" {
   constraints = "~> 5.0"
   hashes = [
     "h1:HkKPMZ/n+QiExkRUSLjGMTGnuIaph+k932LiTp7CKZM=",
+    "h1:LicdZu3hugYpWuCAprg2EslbVP0zANnV9n9/2KiOnYc=",
+    "h1:VvnqJUTXlbKrB/6X2K9dc7lE3CQj3KX055gr+bMyXsg=",
+    "h1:XYVRvCG+auhkY1NnSe6pK7ClqKW5GX8BgUnMQwfC7mQ=",
+    "h1:Xf1PHfUfK690caJYZvoudKKBppfleJ6RcqsEQWqKVCw=",
+    "h1:i6pbudcLi1X2MVeN9IV3bDeiGWnWhn+v9dMrMzAN+l8=",
+    "h1:mopYISyLkUVUwMjJbuPenxIUVDrna1/7ACB1hfMfciU=",
+    "h1:xfoTAyKkR12F8nuVC96DwBA2Fva38o5BnYHLXZzmDP4=",
     "zh:0651618000db705564dab5a25322b9d76ea54b7dd78931ed3565497b559babeb",
     "zh:1a7847e9479fb6d21a65ef933ffae1416b1e4b44ca940c0d6c50fc4248cc4a0d",
     "zh:5597cee5854131045eb9f201ae3a70b59c51955d31a647d9616863c746d902cb",
@@ -22,7 +29,21 @@ provider "registry.opentofu.org/hashicorp/http" {
   version     = "3.6.0"
   constraints = "~> 3.4"
   hashes = [
+    "h1:0n4RBz9zNw6TTddh5+x7E8L2+qzPXNwKhK4uoZ/DUwE=",
+    "h1:22Ob7lpzMBSqdrCvoFN5EgmhGPHPBovV/9qo0c/Cd+A=",
+    "h1:2IRBvmWOYrq/ooaYYn2i86jZb7iIUvlg0KlmOMfDHoQ=",
+    "h1:5mucXikk4OcW3un3u94QnMx4AB4Wfih+sXeMd5QxSNk=",
     "h1:5oU7Zm+2gAVGmxqtJ9E8uTudUkYy/DEn/y3IWphdv4k=",
+    "h1:5w0R4b1/VSzpqQF1tXXPr/qmaQLPVRXamOmPKWFcTk4=",
+    "h1:AEVeJr8xGmwad+JUUQ833C3x5d4W+W2szF5DfwxYppw=",
+    "h1:CPHJ+0zQbS/cX1m55Y90jIOgf1jV3ocUUnqsXAh+9Eg=",
+    "h1:JPewnGDOJudNer5+ghqwXoaJkfot3QRq9uiEYvo+JHU=",
+    "h1:QzbluV2vQLxsJYxjpziQCmPndIoJ/UGS4/UHH/GpwUM=",
+    "h1:TjUNbUdqweRBq/ycQ4ixpNkx5qaYwpXEOn9QCpqNZP8=",
+    "h1:XNbcODP60ajj21N/OO7af8bBg1ltIsYkq9egn7BYbiY=",
+    "h1:tgrbgmX7WYQz9G9ncgu7TkpVB+RlLjJA/Rvp9KPlZH8=",
+    "h1:vLxthX/ZWsOZ+aHKbAMqmNKqD0K5f4nJ8ppy0Ioyup0=",
+    "h1:wZOdGBAZkY8OKEPjKz82j1HloAKOmmvtjWyTxM+I110=",
     "zh:0f719fa5426bc883e9fa6abf7f6498e48025edafbc29015e2f5c028f1cca3b9d",
     "zh:1b4d7dafefd6c61764b2f9ed6943ceb9a200dee3590d18747e3a5f6b20ce85e0",
     "zh:1d23a712984866d29f7b07028a4e99c783c71f1a5dddf08bc3d4e7da9d91a1fa",
@@ -45,7 +66,19 @@ provider "registry.opentofu.org/hetznercloud/hcloud" {
   version     = "1.63.0"
   constraints = "~> 1.48"
   hashes = [
+    "h1:/BDH9OdzcieKCmKvrrzoH7zst/STuBo9QY1eYOHf1qk=",
+    "h1:1Yxj4ZifWjSYntT/IK08jX71yeO6cwLBJ2r1YdrOP+0=",
+    "h1:1rfGuHceQqFhYX0pDpMdy9T7x5AXrS4CQSzHWK6sN4w=",
+    "h1:7W005UxN3VPZob4+kcdbnucDgpNdhHb9T33uWU99ft4=",
+    "h1:DH2SyItmRRQU2szeJYeGXVobvv48YWzR9ds0negRmrA=",
     "h1:FmkJ05xMeApac1/nz5GOAB/s729eMEkjAyThtD4zJxY=",
+    "h1:J8zv0yOD2j0hPLycqRUAUl8SL/0SV6qGKZ/+d7bNeI4=",
+    "h1:QmDRYrjI9j0UP3+eDW97NkzKgdeCEvORVLoGBIwN9a4=",
+    "h1:cnsKDc8YWYCmfubt1YLT91Liu78FfN9n7HKFBbAXRHw=",
+    "h1:ff7zgLGIrGIk+AknBtqQyLlyxVX2gHwDl54F/whP+ZQ=",
+    "h1:jhDhX2StwluRLqS/Uotls04RcGLG4vKS2IrxN+9q3Mc=",
+    "h1:jlE0a47UOQ1v3cFZ56rcD3TOSz9qD/Ik2bsInX3Y9lg=",
+    "h1:qtLpf6u8E1Kp8Z833MBmzm2NBRr1mR7mzOu6Cq7/gH0=",
     "zh:0510f27825d28b065615c6e715a4aae38a50633195a8a88d4507476bb6484c33",
     "zh:0fba95c8fc048155c2211f15f850b75fe33cac96201bcaaa28467b32f6ac568e",
     "zh:11d917ac92ca30fe82d362465a1685b3a9f9a3abcd486b0114ff680746d0af08",

--- a/infra/bootstrap/main.tf
+++ b/infra/bootstrap/main.tf
@@ -13,7 +13,7 @@
 # ============================================================================
 
 terraform {
-  required_version = ">= 1.6.0"
+  required_version = ">= 1.12.0"
 
   required_providers {
     hcloud = {
@@ -104,6 +104,7 @@ module "hetzner" {
   ssh_public_key  = var.ssh_public_key
   ssh_allowed_ips = var.ssh_allowed_ips
   cloud_init      = module.bootstrap.cloud_init
+  prevent_destroy = var.prevent_server_destroy
 }
 
 # ----------------------------------------------------------------------------

--- a/infra/bootstrap/modules/hetzner/main.tf
+++ b/infra/bootstrap/modules/hetzner/main.tf
@@ -111,10 +111,15 @@ resource "hcloud_server" "main" {
   # server whenever user_data changes — so a routine tfvars edit (repo
   # URL, superuser credentials, backup settings) would otherwise destroy
   # the VPS and every Docker volume on it (Postgres data, acme.json,
-  # GlitchTip). Ignore post-create drift; rebuild deliberately with
-  #   tofu apply -replace=module.hetzner.hcloud_server.main
-  # when you really want a fresh server.
+  # GlitchTip). Ignore post-create drift to avoid accidental rebuilds.
+  #
+  # prevent_destroy (var-gated; OpenTofu 1.12+) is the second guard: any
+  # plan that would destroy or -replace this server is rejected while the
+  # flag is true. To deliberately rebuild a fresh box, lower the gate:
+  #   tofu apply -var prevent_server_destroy=false \
+  #     -replace=module.hetzner.hcloud_server.main
   lifecycle {
-    ignore_changes = [user_data]
+    ignore_changes  = [user_data]
+    prevent_destroy = var.prevent_destroy
   }
 }

--- a/infra/bootstrap/modules/hetzner/main.tf
+++ b/infra/bootstrap/modules/hetzner/main.tf
@@ -97,6 +97,15 @@ resource "hcloud_server" "main" {
   firewall_ids = [hcloud_firewall.main.id]
   user_data    = var.cloud_init
 
+  # Hetzner-native protection, enforced by the cloud API independently of
+  # tofu state: blocks deletion/rebuild of this server by ANY actor — the
+  # Hetzner console, the hcloud CLI, a raw API call, or a tofu run with
+  # broken state — not just a tofu plan through this config. This is the
+  # second layer behind lifecycle.prevent_destroy below; both are driven
+  # by the same gate so there is a single explicit switch to lower.
+  delete_protection  = var.prevent_destroy
+  rebuild_protection = var.prevent_destroy
+
   public_net {
     ipv4_enabled = true
     ipv6_enabled = true
@@ -113,10 +122,13 @@ resource "hcloud_server" "main" {
   # the VPS and every Docker volume on it (Postgres data, acme.json,
   # GlitchTip). Ignore post-create drift to avoid accidental rebuilds.
   #
-  # prevent_destroy (var-gated; OpenTofu 1.12+) is the second guard: any
+  # prevent_destroy (var-gated; OpenTofu 1.12+) is the tofu-layer guard: any
   # plan that would destroy or -replace this server is rejected while the
-  # flag is true. To deliberately rebuild a fresh box, lower the gate:
-  #   tofu apply -var prevent_server_destroy=false \
+  # flag is true. Together with delete_protection/rebuild_protection above,
+  # nuking production takes two deliberate, explicit steps — first lower the
+  # gate so the locks lift, then rebuild:
+  #   tofu apply -var prevent_server_destroy=false          # lifts both locks
+  #   tofu apply -var prevent_server_destroy=false \        # then rebuild
   #     -replace=module.hetzner.hcloud_server.main
   lifecycle {
     ignore_changes  = [user_data]

--- a/infra/bootstrap/modules/hetzner/variables.tf
+++ b/infra/bootstrap/modules/hetzner/variables.tf
@@ -32,3 +32,8 @@ variable "cloud_init" {
   type        = string
   description = "Rendered cloud-init YAML, injected as the server's user_data."
 }
+
+variable "prevent_destroy" {
+  type        = bool
+  description = "Guard the VPS against destroy/replace. Set false only for a deliberate rebuild."
+}

--- a/infra/bootstrap/terraform.tfvars.example
+++ b/infra/bootstrap/terraform.tfvars.example
@@ -58,8 +58,11 @@ ssh_allowed_ips = []  # REQUIRED: your admin CIDRs, e.g. ["203.0.113.7/32"].
 # vps_image    = "ubuntu-24.04"
 # vps_name     = "boringstack"
 
-# Guard the VPS against destroy/replace (default true). Set false only for a
-# deliberate rebuild — the box holds all persistent Docker volumes.
+# Guard the VPS against destroy/replace (default true). Drives BOTH the tofu
+# prevent_destroy guard AND Hetzner's API-level delete/rebuild protection, so
+# the box (which holds all persistent Docker volumes) can't be nuked by tofu,
+# the Hetzner console, or the hcloud CLI. Set false + apply only for a
+# deliberate rebuild.
 # prevent_server_destroy = true
 
 # ----------------------------------------------------------------------------

--- a/infra/bootstrap/terraform.tfvars.example
+++ b/infra/bootstrap/terraform.tfvars.example
@@ -58,6 +58,10 @@ ssh_allowed_ips = []  # REQUIRED: your admin CIDRs, e.g. ["203.0.113.7/32"].
 # vps_image    = "ubuntu-24.04"
 # vps_name     = "boringstack"
 
+# Guard the VPS against destroy/replace (default true). Set false only for a
+# deliberate rebuild — the box holds all persistent Docker volumes.
+# prevent_server_destroy = true
+
 # ----------------------------------------------------------------------------
 # Stack secrets  (required)
 # ----------------------------------------------------------------------------

--- a/infra/bootstrap/variables.tf
+++ b/infra/bootstrap/variables.tf
@@ -172,6 +172,12 @@ variable "vps_name" {
   }
 }
 
+variable "prevent_server_destroy" {
+  type        = bool
+  description = "When true (default), block tofu from destroying or replacing the VPS — it holds all persistent Docker volumes (Postgres, acme.json, GlitchTip). Flip to false (e.g. -var prevent_server_destroy=false) only when deliberately rebuilding the host."
+  default     = true
+}
+
 # ============================================================================
 # Repo to clone on first boot
 # ============================================================================


### PR DESCRIPTION
## Context

Goal: make production **hard to nuke**, and require an **explicit** action to do it — defense in depth against accidents. The single Hetzner VPS (`module.hetzner.hcloud_server.main`) carries **every** persistent Docker volume (Postgres data, `acme.json`, GlitchTip), so losing it is catastrophic. OpenTofu 1.12 lets `prevent_destroy` reference input variables, which we use to build a single, explicit "protect" switch across two independent layers.

## Two protection layers (one switch)

Both are driven by the root var **`prevent_server_destroy`** (bool, default `true`):

1. **OpenTofu layer** — `lifecycle.prevent_destroy` on the server. Rejects any plan that would destroy or `-replace` it. Because a blanket `tofu destroy` aborts entirely if *any* resource is protected, this also transitively shields the DNS records + DNSSEC at the tofu layer.
2. **Hetzner API layer** — `delete_protection` + `rebuild_protection` on the server. Enforced by Hetzner's API regardless of tooling: blocks deletion/rebuild from the **Hetzner console, `hcloud` CLI, raw API, or a tofu run with broken state** — not just a plan through this config.

Layer 1 alone only protects tofu runs through this exact config + state. Layer 2 closes that gap.

### Deliberately rebuilding the host (explicit, two-step)
```
tofu apply -var prevent_server_destroy=false                                   # lifts both locks
tofu apply -var prevent_server_destroy=false -replace=module.hetzner.hcloud_server.main   # rebuild
```
The API lock must be lifted by an apply *before* a destroy can succeed, which is exactly the accident-resistance we want.

## Other changes

- **Version floor** — `main.tf`: `required_version` `>= 1.6.0` → `>= 1.12.0` (dynamic `prevent_destroy` errors on older versions).
- **CI** — pin `opentofu/setup-opentofu` to `tofu_version: "1.12.0"` (was unpinned/latest).
- **Docs** — `terraform.tfvars.example` documents the single toggle; the server's inline comment documents both layers and the rebuild path.
- **Lockfile** — `.terraform.lock.hcl` gains the full set of cross-platform `h1:` checksums that 1.12's improved checksum handling adds on `init` (same provider versions).

Scope: **server only** — DNS/DNSSEC left unguarded directly (cheap to recreate, and transitively covered at the tofu layer per above).

## Verification

Ran locally on a freshly installed OpenTofu **1.12.0** (GPG-verified standalone install):

- ✅ `tofu fmt -check -recursive -diff` — clean
- ✅ `tofu init -backend=false` + `tofu validate` — root valid
- ✅ per-module validate (bootstrap, cloudflare, hetzner) — all valid
- ✅ confirmed via `tofu providers schema -json` that `hcloud_server` exposes `delete_protection` + `rebuild_protection`

`validate` passing on 1.12 confirms the dynamic `prevent_destroy` reference is accepted (it errors on older versions). The live destroy-plan behavior check needs real Hetzner/Cloudflare credentials + state and was not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)