### PR TITLE
chore(deps): bump ioredis to 5.11.1 via override (dedupe bullmq's pin)

### DIFF
--- a/apps/api/bun.lock
+++ b/apps/api/bun.lock
@@ -27,7 +27,7 @@
         "elysia-rate-limit": "4.6.2",
         "fs-extra": "11.3.5",
         "handlebars": "4.7.9",
-        "ioredis": "5.10.1",
+        "ioredis": "5.11.1",
         "nodemailer": "9.0.1",
         "openai": "6.42.0",
         "otpauth": "9.5.1",
@@ -84,6 +84,7 @@
   "overrides": {
     "@typescript-eslint/utils": "8.61.0",
     "form-data": "4.0.6",
+    "ioredis": "5.11.1",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
@@ -232,7 +233,7 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
-    "@ioredis/commands": ["@ioredis/commands@1.5.1", "", {}, "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="],
+    "@ioredis/commands": ["@ioredis/commands@1.10.0", "", {}, "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q=="],
 
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
@@ -710,7 +711,7 @@
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
-    "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
+    "cluster-key-slot": ["cluster-key-slot@1.1.1", "", {}, "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -950,7 +951,7 @@
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
 
-    "ioredis": ["ioredis@5.10.1", "", { "dependencies": { "@ioredis/commands": "1.5.1", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA=="],
+    "ioredis": ["ioredis@5.11.1", "", { "dependencies": { "@ioredis/commands": "1.10.0", "cluster-key-slot": "1.1.1", "debug": "4.4.3", "denque": "2.1.0", "redis-errors": "1.2.0", "redis-parser": "3.0.0", "standard-as-callback": "2.1.0" } }, "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A=="],
 
     "is-array-buffer": ["is-array-buffer@3.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A=="],
 
@@ -1045,10 +1046,6 @@
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
-
-    "lodash.defaults": ["lodash.defaults@4.2.0", "", {}, "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="],
-
-    "lodash.isarguments": ["lodash.isarguments@3.1.0", "", {}, "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="],
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -72,7 +72,7 @@
     "elysia-rate-limit": "4.6.2",
     "fs-extra": "11.3.5",
     "handlebars": "4.7.9",
-    "ioredis": "5.10.1",
+    "ioredis": "5.11.1",
     "nodemailer": "9.0.1",
     "openai": "6.42.0",
     "otpauth": "9.5.1",
@@ -127,10 +127,12 @@
   "//overrides": {
     "_": "Why these transitive deps are pinned. Keep each entry in sync with the matching `overrides` key — enforced by the package-override-parity lint-meta rule.",
     "@typescript-eslint/utils": "Single @typescript-eslint/utils resolution across the workspace so the shared @boring-stack-pkg ESLint plugins all load the same utils version. The UI and docs apps mirror this exact pin; a mismatch makes the custom plugins resolve divergent utils copies and fail to load.",
-    "form-data": "Pin patched form-data (GHSA-hmw2-7cc7-3qxx CRLF injection via unescaped multipart field names); 4.0.5 is vulnerable, 4.0.6 patches it. Pulled in transitively via @sendgrid/mail -> @sendgrid/client -> axios. Excluded from the install quarantine while <7 days old."
+    "form-data": "Pin patched form-data (GHSA-hmw2-7cc7-3qxx CRLF injection via unescaped multipart field names); 4.0.5 is vulnerable, 4.0.6 patches it. Pulled in transitively via @sendgrid/mail -> @sendgrid/client -> axios. Excluded from the install quarantine while <7 days old.",
+    "ioredis": "Force a single ioredis resolution across the tree. bullmq 5.78.0 exact-pins ioredis@5.10.1, so bumping the top-level dep to 5.11.1 otherwise leaves bullmq on its own nested 5.10.1 copy — two ioredis instances whose RedisOptions types are structurally incompatible (tsc fails on new Redis(options) calls). This override collapses bullmq's nested copy onto 5.11.1 too; 5.10.1 -> 5.11.1 is a semver patch and the Redis/BullMQ integration tests verify runtime compatibility. Drop this once bullmq advances its own ioredis pin."
   },
   "overrides": {
     "@typescript-eslint/utils": "8.61.0",
-    "form-data": "4.0.6"
+    "form-data": "4.0.6",
+    "ioredis": "5.11.1"
   }
 }


### PR DESCRIPTION
## What

Lands the `ioredis` 5.10.1 → 5.11.1 bump (Dependabot #192) that was deferred from #190/#196, by resolving the dependency-tree split that blocked it.

## Why it was blocked

`bullmq` 5.78.0 **exact-pins** `ioredis@5.10.1`. Bumping only the top-level dep left bullmq on its own nested `5.10.1` copy — two `ioredis` instances whose `RedisOptions` types are structurally incompatible, so `tsc` failed on every `new Redis(options)` call.

## Fix

Add an `ioredis: 5.11.1` override in `apps/api` that collapses bullmq's nested copy onto the top-level version. `5.10.1 → 5.11.1` is a semver patch; the override is documented in `//overrides` and should be dropped once bullmq advances its own pin.

## Verification (infra up)

- Clean `bun install --frozen-lockfile` (the CI condition) resolves a **single** `ioredis@5.11.1` — no nested copy.
- `bun run check` (tsc + eslint + lint:meta + knip) ✓
- `bun run test` → **1188 pass / 0 fail**, including the Redis/BullMQ/valkey integration tests.

Supersedes #192.