### PR TITLE
fix(codegen): new:resource emits requireAuth (createAuthMiddleware does not exist)

### DIFF
--- a/apps/api/scripts/codegen/new-resource.ts
+++ b/apps/api/scripts/codegen/new-resource.ts
@@ -297,12 +297,12 @@ export const ${filePrefix}Service = new ${pascal}Service();
   await Bun.write(
     `${dirPath}/${filePrefix}.routes.ts`,
     `import { t } from "elysia";
-import { createAuthMiddleware } from "../auth/auth.plugin";
+import { requireAuth } from "../auth/auth.plugin";
 import { errorHandler } from "../../middleware/error-handler";
 import { ${createSchemaName}, ${responseName} } from "./${filePrefix}.schemas";
 import { ${filePrefix}Service } from "./${filePrefix}.service";
 
-const ${filePrefix}Routes = createAuthMiddleware()
+const ${filePrefix}Routes = requireAuth()
   .onError(({ code, error, set }) =>
     errorHandler({ code: String(code), error, set })
   )


### PR DESCRIPTION
The `new:resource` template imported `createAuthMiddleware` from `auth.plugin`, but that module only exports `requireAuth`/`tryAuth` — so **every generated resource failed typecheck** (TS2305 + implicit-any cascade). Real resources (e.g. `dashboard.routes.ts`) use `requireAuth()`; this aligns the generator with them.

Verified: a generated resource typechecks + passes `apps/api` `bun run validate` after this change.

(Discovered by tsforge's harness driving `new:resource` end-to-end.)