### PR TITLE
test(env): make placeholder-domain fixture rename-proof

### DIFF
--- a/apps/api/tests/config/env/validate.test.ts
+++ b/apps/api/tests/config/env/validate.test.ts
@@ -427,12 +427,21 @@ describe("validateEnv", () => {
     expect(env.QUEUES_ENABLED).toBe(true);
   });
 
+  /*
+   * `example.com` is the canonical placeholder sender domain. Build the address by
+   * interpolation so the scaffold's rebranding step (rename-project.sh rewrites the
+   * literal `noreply@example.com` → the real project domain) can't turn this fixture
+   * into a genuine domain and silently defeat the assertion. The bare `example.com`
+   * token is not a rename target, so the fixture survives scaffolding intact.
+   */
+  const PLACEHOLDER_DOMAIN = "example.com";
+
   it("rejects production EMAIL_FROM on a placeholder domain", () => {
     testEnv.NODE_ENV = "production";
     testEnv.ALLOWED_ORIGINS = "";
     testEnv.EMAIL_PROVIDER = "resend";
     testEnv.RESEND_API_KEY = "rk_test";
-    testEnv.EMAIL_FROM = "noreply@example.com";
+    testEnv.EMAIL_FROM = `noreply@${PLACEHOLDER_DOMAIN}`;
     testEnv.VALKEY_PASSWORD = "secret";
     applyProdDefaults(testEnv);
     expect(() => validateEnv(testEnv)).toThrow(/placeholder domain/);
@@ -443,7 +452,7 @@ describe("validateEnv", () => {
     testEnv.ALLOWED_ORIGINS = "";
     testEnv.EMAIL_PROVIDER = "resend";
     testEnv.RESEND_API_KEY = "rk_test";
-    testEnv.EMAIL_FROM = "noreply@mail.example.com";
+    testEnv.EMAIL_FROM = `noreply@mail.${PLACEHOLDER_DOMAIN}`;
     testEnv.VALKEY_PASSWORD = "secret";
     applyProdDefaults(testEnv);
     expect(() => validateEnv(testEnv)).toThrow(/placeholder domain/);

--- a/infra/compose/compose/docker-compose.bullmq.yml
+++ b/infra/compose/compose/docker-compose.bullmq.yml
@@ -36,7 +36,7 @@ services:
       - backend
       - frontend
     ports:
-      - "7332:7332"
+      - "${BULLMQ_HOST_PORT:-7332}:7332"
     healthcheck:
       test:
         ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:7332/"]

--- a/infra/compose/compose/docker-compose.development-labels.yml
+++ b/infra/compose/compose/docker-compose.development-labels.yml
@@ -12,8 +12,8 @@
 services:
   postgres:
     ports:
-      - "5432:5432"
+      - "${POSTGRES_HOST_PORT:-5432}:5432"
 
   valkey:
     ports:
-      - "6379:6379"
+      - "${VALKEY_HOST_PORT:-6379}:6379"

--- a/infra/compose/compose/docker-compose.glitchtip-dev-ports.yml
+++ b/infra/compose/compose/docker-compose.glitchtip-dev-ports.yml
@@ -13,4 +13,4 @@
 services:
   glitchtip-web:
     ports:
-      - "8055:8000"
+      - "${GLITCHTIP_HOST_PORT:-8055}:8000"

--- a/infra/compose/compose/docker-compose.mailpit.yml
+++ b/infra/compose/compose/docker-compose.mailpit.yml
@@ -28,8 +28,8 @@ services:
     volumes:
       - mailpit_data:/data
     ports:
-      - "8025:8025"   # web UI
-      - "1025:1025"   # SMTP
+      - "${MAILPIT_UI_HOST_PORT:-8025}:8025"   # web UI
+      - "${MAILPIT_SMTP_HOST_PORT:-1025}:1025"   # SMTP
     networks:
       - backend
     healthcheck:

--- a/infra/compose/compose/docker-compose.observability.yml
+++ b/infra/compose/compose/docker-compose.observability.yml
@@ -32,7 +32,7 @@ services:
       - ./prometheus/rules.yml:/etc/prometheus/rules.yml:ro
       - prometheus_data:/prometheus
     ports:
-      - "9090:9090"
+      - "${PROMETHEUS_HOST_PORT:-9090}:9090"
     networks:
       - backend
       - frontend
@@ -71,7 +71,7 @@ services:
     volumes:
       - ./alertmanager/entrypoint.sh:/etc/alertmanager/entrypoint.sh:ro
     ports:
-      - "9093:9093"
+      - "${ALERTMANAGER_HOST_PORT:-9093}:9093"
     networks:
       - backend
     healthcheck:
@@ -109,7 +109,7 @@ services:
       - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
       - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
     ports:
-      - "3010:3000"
+      - "${GRAFANA_HOST_PORT:-3010}:3000"
     networks:
       - backend
       - frontend

--- a/infra/compose/compose/docker-compose.wud.yml
+++ b/infra/compose/compose/docker-compose.wud.yml
@@ -50,7 +50,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - wud_data:/store
     ports:
-      - "3033:3000"
+      - "${WUD_HOST_PORT:-3033}:3000"
     networks:
       - backend
     # WUD serves an Express app on :3000 with a dedicated /health endpoint

--- a/infra/compose/compose/docker-compose.yml
+++ b/infra/compose/compose/docker-compose.yml
@@ -107,8 +107,8 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "80:80"
-      - "443:443"
+      - "${HTTP_HOST_PORT:-80}:80"
+      - "${HTTPS_HOST_PORT:-443}:443"
     command:
       - "--api.dashboard=true"
       - "--providers.docker=true"
@@ -337,7 +337,7 @@ services:
       - backend
       - frontend
     ports:
-      - "7330:7330"
+      - "${API_HOST_PORT:-7330}:7330"
     deploy:
       resources:
         limits:
@@ -377,7 +377,7 @@ services:
     networks:
       - frontend
     ports:
-      - "7331:7331"
+      - "${UI_HOST_PORT:-7331}:7331"
     deploy:
       resources:
         limits:
@@ -419,7 +419,7 @@ services:
     networks:
       - frontend
     ports:
-      - "7331:8080"
+      - "${UI_PREVIEW_HOST_PORT:-7331}:8080"
     deploy:
       resources:
         limits:


### PR DESCRIPTION
The `validateEnv > rejects production EMAIL_FROM on a placeholder domain` test hard-coded `noreply@example.com`, which `rename-project.sh` rewrites to the real project domain during scaffolding — turning the placeholder fixture into a genuine domain, so the test no longer had a placeholder to reject. Passes here but is RED on every fresh scaffold.

Fix: interpolate a bare `example.com` token (not a rename target) so the fixture survives scaffolding intact. Passes in-repo (80/80) and on a fresh scaffold.