### PR TITLE
feat(compose): parameterize host ports for per-project isolation

### DIFF
--- a/infra/compose/compose/docker-compose.bullmq.yml
+++ b/infra/compose/compose/docker-compose.bullmq.yml
@@ -36,7 +36,7 @@ services:
       - backend
       - frontend
     ports:
-      - "7332:7332"
+      - "${BULLMQ_HOST_PORT:-7332}:7332"
     healthcheck:
       test:
         ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:7332/"]

--- a/infra/compose/compose/docker-compose.development-labels.yml
+++ b/infra/compose/compose/docker-compose.development-labels.yml
@@ -12,8 +12,8 @@
 services:
   postgres:
     ports:
-      - "5432:5432"
+      - "${POSTGRES_HOST_PORT:-5432}:5432"
 
   valkey:
     ports:
-      - "6379:6379"
+      - "${VALKEY_HOST_PORT:-6379}:6379"

--- a/infra/compose/compose/docker-compose.glitchtip-dev-ports.yml
+++ b/infra/compose/compose/docker-compose.glitchtip-dev-ports.yml
@@ -13,4 +13,4 @@
 services:
   glitchtip-web:
     ports:
-      - "8055:8000"
+      - "${GLITCHTIP_HOST_PORT:-8055}:8000"

--- a/infra/compose/compose/docker-compose.mailpit.yml
+++ b/infra/compose/compose/docker-compose.mailpit.yml
@@ -28,8 +28,8 @@ services:
     volumes:
       - mailpit_data:/data
     ports:
-      - "8025:8025"   # web UI
-      - "1025:1025"   # SMTP
+      - "${MAILPIT_UI_HOST_PORT:-8025}:8025"   # web UI
+      - "${MAILPIT_SMTP_HOST_PORT:-1025}:1025"   # SMTP
     networks:
       - backend
     healthcheck:

--- a/infra/compose/compose/docker-compose.observability.yml
+++ b/infra/compose/compose/docker-compose.observability.yml
@@ -32,7 +32,7 @@ services:
       - ./prometheus/rules.yml:/etc/prometheus/rules.yml:ro
       - prometheus_data:/prometheus
     ports:
-      - "9090:9090"
+      - "${PROMETHEUS_HOST_PORT:-9090}:9090"
     networks:
       - backend
       - frontend
@@ -71,7 +71,7 @@ services:
     volumes:
       - ./alertmanager/entrypoint.sh:/etc/alertmanager/entrypoint.sh:ro
     ports:
-      - "9093:9093"
+      - "${ALERTMANAGER_HOST_PORT:-9093}:9093"
     networks:
       - backend
     healthcheck:
@@ -109,7 +109,7 @@ services:
       - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
       - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
     ports:
-      - "3010:3000"
+      - "${GRAFANA_HOST_PORT:-3010}:3000"
     networks:
       - backend
       - frontend

--- a/infra/compose/compose/docker-compose.wud.yml
+++ b/infra/compose/compose/docker-compose.wud.yml
@@ -50,7 +50,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - wud_data:/store
     ports:
-      - "3033:3000"
+      - "${WUD_HOST_PORT:-3033}:3000"
     networks:
       - backend
     # WUD serves an Express app on :3000 with a dedicated /health endpoint

--- a/infra/compose/compose/docker-compose.yml
+++ b/infra/compose/compose/docker-compose.yml
@@ -107,8 +107,8 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "80:80"
-      - "443:443"
+      - "${HTTP_HOST_PORT:-80}:80"
+      - "${HTTPS_HOST_PORT:-443}:443"
     command:
       - "--api.dashboard=true"
       - "--providers.docker=true"
@@ -337,7 +337,7 @@ services:
       - backend
       - frontend
     ports:
-      - "7330:7330"
+      - "${API_HOST_PORT:-7330}:7330"
     deploy:
       resources:
         limits:
@@ -377,7 +377,7 @@ services:
     networks:
       - frontend
     ports:
-      - "7331:7331"
+      - "${UI_HOST_PORT:-7331}:7331"
     deploy:
       resources:
         limits:
@@ -419,7 +419,7 @@ services:
     networks:
       - frontend
     ports:
-      - "7331:8080"
+      - "${UI_PREVIEW_HOST_PORT:-7331}:8080"
     deploy:
       resources:
         limits:


### PR DESCRIPTION
Every host port was hard-coded (5432/7330/7331/…), so two projects from this template collide and can't run side by side. Each host port is now `${<SERVICE>_HOST_PORT:-<current>}` — **defaults preserve today's behavior exactly** (nothing you run changes), but a consumer (tsforge scaffolding a project) can set free ports in `compose/.env` so a scaffolded stack boots alongside the dev stack without collision. 14 bindings / 7 files; `docker compose config` validates and binds the overridden ports (verified: postgres published on an allocated free port, not 5432).

The compose project name is already per-project via `rename-project.sh`; this closes the ports half. Stacked on #278 (the rename-proof test fix).