### PR TITLE
chore(deps): stop Dependabot re-proposing elysia-rate-limit majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,13 @@ updates:
     ignore:
       - dependency-name: "elysia"
         update-types: ["version-update:semver-major"]
+      # elysia-rate-limit 5.x requires `elysia >= 2.0.0`, but Elysia has no
+      # stable 2.0.0 — the 2.x line exists only under the `next`/`experimental`
+      # dist-tags, and `elysia` itself is major-ignored just above. Stay on
+      # 4.6.2 (peer `elysia >= 1.0.0`) until Elysia 2 ships stable and we do
+      # that upgrade deliberately.
+      - dependency-name: "elysia-rate-limit"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "drizzle-orm"
         update-types: ["version-update:semver-major"]
       - dependency-name: "drizzle-kit"


### PR DESCRIPTION
Follow-up to #361, which left #351 as the only open PR.

## Why #351 cannot be merged

`elysia-rate-limit@5.x` declares `elysia >= 2.0.0` as a peer dependency. **Elysia has no stable 2.0.0:**

```
$ npm view elysia dist-tags
{
  "latest":       "1.4.29",   <- what apps/api runs
  "next":         "2.0.0-beta.4",
  "experimental": "2.0.0-exp.63",
  "rc":           "1.2.0-rc.3"
}
```

The 2.x line exists only as beta/experimental prereleases. Taking `elysia-rate-limit@5.1.0` would mean running the API on an Elysia beta, so this is blocked on upstream shipping a stable Elysia 2 — not on work we can schedule.

Meanwhile `elysia` is *already* major-ignored in this file, so Dependabot will never propose the Elysia 2 side of the pair. The result is a permanently unmergeable PR regenerated every week.

## Change

Adds a matching major-ignore for `elysia-rate-limit`, with a comment recording why. This mirrors the existing `@astrojs/cloudflare` entry in the docs ecosystem, held back for exactly the same reason: a plugin major requiring a framework major we have not taken.

`elysia-rate-limit@4.6.2` stays — it is the newest 4.x, and its peer range (`elysia >= 1.0.0`) is satisfied. Minor and patch updates within 4.x are unaffected.

## When to revisit

When Elysia promotes 2.x to `latest`, drop both this entry and the `elysia` major-ignore and do the upgrade deliberately. Note the v5 migration also touches our custom Valkey `Context` in `apps/api/src/lib/rate-limit/valkey-context.ts`, not just the version pin.

Closing #351 as part of this.