### PR TITLE
fix(docs): show the git clone fallback in the homepage transcript

### DIFF
--- a/apps/docs/scripts/check-agent-surface.mjs
+++ b/apps/docs/scripts/check-agent-surface.mjs
@@ -268,6 +268,31 @@ if (/click\s+\*{0,2}Use this template/i.test(agents)) {
   );
 }
 
+/* -------------------------------------------------- the homepage transcript */
+
+/* An agent that fetched only the homepage read `gh repo create --template` in
+ * the transcript and concluded it "will require you to authenticate with
+ * GitHub in your browser". It does not: the installer falls back to
+ * `git clone` on the public repo. agents.md said so, the homepage did not, and
+ * the homepage is the page an agent hits first. Keep the fallback visible in
+ * whichever surface names `gh`. */
+const landing = readFileSync(
+  join(DOCS, "src", "components", "landing", "landingContent.ts"),
+  "utf8",
+);
+if (landing.includes("gh repo create") && !/git clone/.test(landing)) {
+  fail(
+    "the homepage names `gh repo create` without the `git clone` fallback",
+    "an agent reading only the homepage concludes a browser login is required",
+  );
+}
+if (!/auth(entication)? is optional/i.test(landing)) {
+  fail(
+    "the homepage does not say GitHub auth is optional",
+    "add it to the agent tab caption in landingContent.ts",
+  );
+}
+
 /* ---------------------------------------------------------------- robots */
 
 const robots = read("robots.txt");

--- a/apps/docs/src/components/landing/landingContent.ts
+++ b/apps/docs/src/components/landing/landingContent.ts
@@ -38,7 +38,7 @@ export const codeTabs: CodeTab[] = [
       { kind: "command", text: "curl -fsSL https://boringstack.xyz/install.sh | sh -s -- --project acme" },
       { kind: "spacer" },
       { kind: "ok", text: "[1/5] preflight  compose v2, ports free, 12GB" },
-      { kind: "ok", text: "[2/5] scaffold   gh repo create --template" },
+      { kind: "ok", text: "[2/5] scaffold   gh repo create (or git clone)" },
       { kind: "ok", text: "[3/5] rename     boringstack -> acme" },
       { kind: "ok", text: "[4/5] boot       ./setup.sh --up" },
       { kind: "ok", text: "[5/5] health     ui 200, api 200" },
@@ -46,7 +46,7 @@ export const codeTabs: CodeTab[] = [
       { kind: "muted", text: "# ready -> http://localhost:7331" },
     ],
     caption:
-      "Point an agent at the domain and it has everything it needs in one fetch.",
+      "Point an agent at the domain and it has everything it needs in one fetch. GitHub auth is optional. Without it the installer clones the public repo, so nothing waits on a browser login.",
   },
 
   {


### PR DESCRIPTION
## Why

Post-merge acid test of #430: pointed a fresh agent at `boringstack.xyz` with no other context. It found and quoted the install command unprompted, which is the win. But it also inferred a step that does not exist:

> one step requires human interaction: `gh repo create --template`, which will require you to authenticate with GitHub in your browser

That is wrong. `install.sh` falls back to `git clone --depth 1` on the public repo when `gh` is unauthenticated, and has no `read` and no `/dev/tty` anywhere.

`/agents.md` answers it correctly today. The homepage did not, and the homepage is the page an agent hits first, so the right answer was one fetch away from where it was needed.

## What changed

- The agent tab transcript reads `gh repo create (or git clone)` instead of `gh repo create --template`.
- The tab caption says GitHub auth is optional and nothing waits on a browser login.
- `check:agent-surface` fails the build if `landingContent.ts` names `gh repo create` without a `git clone` fallback, or drops the "auth is optional" line.

## Verification

```
$ node scripts/check-agent-surface.mjs   # clean
agent-surface: ok
exit=0

$ # with either half reverted
  ✗ the homepage names `gh repo create` without the `git clone` fallback
  ✗ the homepage does not say GitHub auth is optional
exit=1
```

`bun run build:ci` green (77 pages, all four checks).