### PR TITLE
fix(docs): keep the install command intact when the homepage is flattened

### DIFF
--- a/apps/docs/scripts/check-agent-surface.mjs
+++ b/apps/docs/scripts/check-agent-surface.mjs
@@ -309,20 +309,71 @@ if (!/auth(entication)? is optional/i.test(landing)) {
  * So flatten dist/index.html the way a converter does, honouring block-level
  * tags only, and assert the command survives intact.
  */
+/*
+ * A scanner, not a chain of regex replaces. Stripping `<script>` with
+ * `.replace(/<(script|style)\b[\s\S]*?<\/\1>/g, "")` is the exact pattern
+ * CodeQL's incomplete-multi-character-sanitization rule exists to catch, and
+ * it is right to: a regex cannot reliably find the end of a tag it does not
+ * tokenize. Walking the input once is both quieter and more correct.
+ */
+const BLOCK_TAGS = new Set([
+  "address", "article", "aside", "blockquote", "br", "dd", "div", "dl", "dt",
+  "fieldset", "figcaption", "figure", "footer", "form", "h1", "h2", "h3", "h4",
+  "h5", "h6", "header", "hr", "li", "main", "nav", "ol", "p", "pre", "section",
+  "table", "tbody", "td", "tfoot", "th", "thead", "tr", "ul",
+]);
+const SKIP_CONTENT_TAGS = new Set(["script", "style", "template", "svg", "noscript"]);
+const ENTITIES = new Map([
+  ["nbsp", " "], ["amp", "&"], ["lt", "<"], ["gt", ">"], ["quot", '"'],
+  ["apos", "'"], ["#39", "'"], ["#039", "'"], ["#x27", "'"],
+]);
+
+const decodeEntities = (text) =>
+  text.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (whole, name) => {
+    const known = ENTITIES.get(name.toLowerCase());
+    if (known !== undefined) return known;
+    if (name.startsWith("#x") || name.startsWith("#X")) {
+      return String.fromCodePoint(Number.parseInt(name.slice(2), 16));
+    }
+    if (name.startsWith("#")) return String.fromCodePoint(Number.parseInt(name.slice(1), 10));
+    return whole;
+  });
+
 const flatten = (rawHtml) => {
-  const body = rawHtml.includes("<body") ? rawHtml.slice(rawHtml.indexOf("<body")) : rawHtml;
-  const BLOCK =
-    "div|p|li|tr|h[1-6]|section|header|footer|nav|ul|ol|table|main|article|br|pre|blockquote|dd|dt";
-  return body
-    .replace(/<(script|style)\b[\s\S]*?<\/\1>/g, "")
-    .replace(new RegExp(`</?(?:${BLOCK})\\b[^>]*>`, "g"), "\n")
-    .replace(/<[^>]+>/g, "")
-    .replace(/&nbsp;/g, " ")
-    .replace(/&quot;/g, '"')
-    .replace(/&#0?39;|&apos;/g, "'")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&amp;/g, "&");
+  const out = [];
+  let i = rawHtml.indexOf("<body");
+  if (i === -1) i = 0;
+  let skipUntilCloseOf = null;
+
+  while (i < rawHtml.length) {
+    const lt = rawHtml.indexOf("<", i);
+    if (lt === -1) {
+      if (!skipUntilCloseOf) out.push(rawHtml.slice(i));
+      break;
+    }
+    if (!skipUntilCloseOf && lt > i) out.push(rawHtml.slice(i, lt));
+
+    const gt = rawHtml.indexOf(">", lt);
+    if (gt === -1) break;
+
+    const raw = rawHtml.slice(lt + 1, gt);
+    const closing = raw.startsWith("/");
+    const name = (closing ? raw.slice(1) : raw)
+      .split(/[\s/>]/, 1)[0]
+      .toLowerCase();
+
+    if (skipUntilCloseOf) {
+      if (closing && name === skipUntilCloseOf) skipUntilCloseOf = null;
+    } else if (!closing && SKIP_CONTENT_TAGS.has(name) && !raw.endsWith("/")) {
+      skipUntilCloseOf = name;
+    } else if (BLOCK_TAGS.has(name)) {
+      // A block boundary is a line break with no CSS required. This is the
+      // whole point of the check.
+      out.push("\n");
+    }
+    i = gt + 1;
+  }
+  return decodeEntities(out.join(""));
 };
 
 const homeText = flatten(read("index.html"));
@@ -353,9 +404,17 @@ for (const fused of homeText.match(/\bacme\w+/g) ?? []) {
     "adjacent text fused onto the command; the separator before it is CSS-only",
   );
 }
-// Each agent entrypoint must read as its own path, not one run of them.
+/* Each agent entrypoint must read as its own token, not one run of them.
+ * Set membership over the split text, rather than a regex built from the path,
+ * so there is no escaping to get wrong. */
+const homeTokens = new Set(
+  homeText
+    .split(/[\s,()]+/)
+    .map((token) => token.replace(/[.]+$/, ""))
+    .filter(Boolean),
+);
 for (const path of ["/agents.md", "/install.sh", "/scaffold-manifest.json"]) {
-  if (!new RegExp(`(^|[\\s(])${path.replace(/[.]/g, "\\.")}([\\s,.)]|$)`, "m").test(homeText)) {
+  if (!homeTokens.has(path)) {
     fail(
       `${path} does not stand alone in the flattened homepage`,
       "the link row needs block-level items; a flex gap is not a text separator",

--- a/apps/docs/scripts/check-agent-surface.mjs
+++ b/apps/docs/scripts/check-agent-surface.mjs
@@ -293,6 +293,76 @@ if (!/auth(entication)? is optional/i.test(landing)) {
   );
 }
 
+/* ------------------------------------------- the homepage survives flattening */
+
+/*
+ * An agent does not read the homepage, it reads a text conversion of it, and
+ * the conversion has no CSS. Anything whose only separator is a Tailwind
+ * `block` class, a flex `gap`, or whitespace the minifier is free to drop
+ * arrives as one fused token.
+ *
+ * This shipped: the transcript gutter is a `<span>`, so the `ok` marker of one
+ * line fused onto the end of the previous one and the install command came out
+ * as `--project acmeok`. The footer entrypoint row fused into
+ * `/agents.md/install.sh/scaffold-manifest.json...`.
+ *
+ * So flatten dist/index.html the way a converter does, honouring block-level
+ * tags only, and assert the command survives intact.
+ */
+const flatten = (rawHtml) => {
+  const body = rawHtml.includes("<body") ? rawHtml.slice(rawHtml.indexOf("<body")) : rawHtml;
+  const BLOCK =
+    "div|p|li|tr|h[1-6]|section|header|footer|nav|ul|ol|table|main|article|br|pre|blockquote|dd|dt";
+  return body
+    .replace(/<(script|style)\b[\s\S]*?<\/\1>/g, "")
+    .replace(new RegExp(`</?(?:${BLOCK})\\b[^>]*>`, "g"), "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;|&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+};
+
+const homeText = flatten(read("index.html"));
+
+/* Pulled from the source rather than hardcoded, so this check cannot pass
+ * against a command the page no longer shows. */
+const installCommandMatch = landing.match(
+  /export const installCommand\s*=\s*\n?\s*"([^"]+)"/,
+);
+if (!installCommandMatch) {
+  fail(
+    "cannot find `export const installCommand` in landingContent.ts",
+    "check-agent-surface parses it to verify the homepage renders it intact",
+  );
+}
+const installCommand = installCommandMatch?.[1] ?? "";
+
+// The command an agent copies must appear verbatim, with nothing fused to it.
+if (installCommand && !homeText.includes(installCommand)) {
+  fail(
+    "the install command does not survive flattening dist/index.html to text",
+    "a gutter or separator is CSS-only; use a block element so the text stream breaks",
+  );
+}
+for (const fused of homeText.match(/\bacme\w+/g) ?? []) {
+  fail(
+    `flattened homepage contains "${fused}" where the project name should end`,
+    "adjacent text fused onto the command; the separator before it is CSS-only",
+  );
+}
+// Each agent entrypoint must read as its own path, not one run of them.
+for (const path of ["/agents.md", "/install.sh", "/scaffold-manifest.json"]) {
+  if (!new RegExp(`(^|[\\s(])${path.replace(/[.]/g, "\\.")}([\\s,.)]|$)`, "m").test(homeText)) {
+    fail(
+      `${path} does not stand alone in the flattened homepage`,
+      "the link row needs block-level items; a flex gap is not a text separator",
+    );
+  }
+}
+
 /* ---------------------------------------------------------------- robots */
 
 const robots = read("robots.txt");

--- a/apps/docs/src/components/Footer.astro
+++ b/apps/docs/src/components/Footer.astro
@@ -29,12 +29,24 @@ import { Icon } from "@astrojs/starlight/components";
     class="mx-auto flex w-fit flex-wrap items-center justify-center gap-x-1 gap-y-1 text-xs text-[var(--sl-color-gray-3)] [&_a]:rounded-full [&_a]:border [&_a]:border-transparent [&_a]:px-2 [&_a]:py-1 [&_a]:font-mono [&_a]:text-[var(--sl-color-gray-3)] [&_a]:no-underline [&_a]:transition-colors [&_a:hover]:border-[color-mix(in_srgb,var(--sl-color-accent)_34%,transparent)] [&_a:hover]:text-[var(--sl-color-white)]"
   >
     <span class="pr-1 not-italic">For agents:</span>
-    <a href="/agents.md">/agents.md</a>
-    <a href="/install.sh">/install.sh</a>
-    <a href="/scaffold-manifest.json">/scaffold-manifest.json</a>
-    <a href="/llms.txt">/llms.txt</a>
-    <a href="/llms-small.txt">/llms-small.txt</a>
-    <a href="/llms-full.txt">/llms-full.txt</a>
+    {/*
+      A real list, not a flex run of bare anchors. The visual spacing here is
+      `gap-x-1`, which puts no separator in the text stream, and the HTML
+      minifier drops the whitespace between the source lines: an agent
+      converting the page read the whole row as one token,
+      `/agents.md/install.sh/scaffold-manifest.json...`. `<li>` is a line
+      break by tag name and needs no CSS to survive the conversion.
+    */}
+    <ul
+      class="m-0 flex list-none flex-wrap items-center justify-center gap-x-1 gap-y-1 p-0 [&_li]:m-0 [&_li]:p-0"
+    >
+      <li><a href="/agents.md">/agents.md</a></li>
+      <li><a href="/install.sh">/install.sh</a></li>
+      <li><a href="/scaffold-manifest.json">/scaffold-manifest.json</a></li>
+      <li><a href="/llms.txt">/llms.txt</a></li>
+      <li><a href="/llms-small.txt">/llms-small.txt</a></li>
+      <li><a href="/llms-full.txt">/llms-full.txt</a></li>
+    </ul>
   </nav>
 
   {

--- a/apps/docs/src/components/landing/CodePreview.tsx
+++ b/apps/docs/src/components/landing/CodePreview.tsx
@@ -10,30 +10,45 @@ const tabBaseClass =
 const panelClass =
   "!mt-0 grid min-h-0 gap-[0.24rem] overflow-x-auto bg-[color-mix(in_oklch,var(--bs-bg)_60%,transparent)] p-4 font-mono text-[0.8rem] leading-[1.6] text-[var(--bs-code)] min-[641px]:h-[19rem] min-[641px]:p-[1.25rem_1.35rem] min-[641px]:text-[0.8rem]";
 
+/*
+ * Every line is a real block element, and every gutter glyph carries a
+ * trailing space in the text stream.
+ *
+ * These were `<span className="block">` with the glyph flush against the
+ * text. `block` is a Tailwind class, so an agent converting the page to
+ * text has no CSS and reads a `<span>` as inline: the whole transcript
+ * collapsed into one run and the `ok` gutter of the next line fused onto
+ * the end of the previous one. The command came out as
+ * `--project acmeok`, on the one element of the page an agent is most
+ * likely to copy. `<div>` is a line break by tag name, with no CSS
+ * needed; the panel is a grid, so the layout is unchanged.
+ */
 function CodeLineView({ line }: { line: CodeLine }) {
   if (line.kind === "spacer") {
-    return <span aria-hidden="true" className="h-[0.7rem]" />;
+    return <div aria-hidden="true" className="h-[0.7rem]" />;
   }
 
   if (line.kind === "command") {
     return (
-      <span className="block whitespace-nowrap">
-        <span className="inline-flex w-[2.45rem] font-extrabold text-[#e6c26f]">$</span>
+      <div className="whitespace-nowrap">
+        <span className="inline-flex w-[2.45rem] font-extrabold text-[#e6c26f]">{"$ "}</span>
         {line.text}
-      </span>
+      </div>
     );
   }
 
   if (line.kind === "ok") {
     return (
-      <span className="block whitespace-nowrap">
-        <span className="inline-flex w-[2.45rem] font-extrabold text-[var(--bs-success)]">ok</span>
+      <div className="whitespace-nowrap">
+        <span className="inline-flex w-[2.45rem] font-extrabold text-[var(--bs-success)]">
+          {"ok "}
+        </span>
         {line.text}
-      </span>
+      </div>
     );
   }
 
-  return <span className="block whitespace-nowrap text-[#7f8c86]">{line.text}</span>;
+  return <div className="whitespace-nowrap text-[#7f8c86]">{line.text}</div>;
 }
 
 export function CodePreview() {

--- a/apps/docs/src/components/landing/DocsGuide.tsx
+++ b/apps/docs/src/components/landing/DocsGuide.tsx
@@ -35,15 +35,15 @@ export function DocsGuide() {
             href={step.href}
             key={step.number}
           >
-            <span className="mt-0.5 font-mono text-[0.92rem] font-extrabold leading-snug text-[var(--bs-accent-strong)]">
+            <div className="mt-0.5 font-mono text-[0.92rem] font-extrabold leading-snug text-[var(--bs-accent-strong)]">
               {step.number}
-            </span>
-            <span className="grid min-w-0 gap-1">
+            </div>
+            <div className="grid min-w-0 gap-1">
               <strong className="text-[1.08rem] leading-tight text-[var(--bs-text)] group-hover:text-[var(--bs-accent-strong)] min-[641px]:text-[1.26rem]">
                 {step.title}
               </strong>
               <small className="leading-[1.62] text-[var(--bs-muted)]">{step.detail}</small>
-            </span>
+            </div>
           </a>
         ))}
       </div>


### PR DESCRIPTION
## Why

Re-ran the acid test after #431 deployed. The browser-login inference is gone, which was the point of that PR. But the agent handed back a subtly wrong command:

```
curl -fsSL https://boringstack.xyz/install.sh | sh -s -- --project acmeok
```

`acmeok`. The `ok` gutter marker from the next transcript line had fused onto the end of the project name.

Root cause: an agent reads a text conversion of the page, and that conversion has no CSS. Three separators on the homepage existed only in CSS, so the text stream had nothing to break on.

| Element | Separator | Flattened as |
|---|---|---|
| Transcript line | `<span>` + Tailwind `block` | `--project acmeok[1/5] preflight` |
| Footer entrypoints | flex `gap-x-1`, source whitespace minified away | `/agents.md/install.sh/scaffold-manifest.json` |
| DocsGuide step | inline `<span>` number | `01Hand your agent one page.` |

The transcript one is the one that matters: it corrupts the single command this whole surface exists to deliver, on the element an agent is most likely to copy.

## What changed

Lines are block elements, gutter glyphs carry a trailing space in the text stream, and the footer row is a real `<ul>`. The panel is a CSS grid and the footer nav is still flex, so nothing moves visually.

`check:agent-surface` grew the check that generalises this: flatten `dist/index.html` honouring block-level tags only, then assert the install command survives verbatim, no `acme`-prefixed token is fused, and each entrypoint path stands alone. The command is parsed out of `landingContent.ts` rather than hardcoded, so the check can't pass against a command the page no longer shows.

## Verification

Against a build with the old renderer restored:

```
✗ flattened homepage contains "acmeok" where the project name should end
✗ /install.sh does not stand alone in the flattened homepage
✗ /scaffold-manifest.json does not stand alone in the flattened homepage
exit=1
```

Clean: `agent-surface: ok`, `bun run build:ci` green across all four checks, 77 pages.