### PR TITLE
fix(agent): isolate candidate verification and stabilize CI startup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -207,6 +207,26 @@ updates:
       - dependency-name: "traefik"
         update-types: ["version-update:semver-major"]
 
+  - package-ecosystem: docker
+    directory: /tools/agent-evals/isolated
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 4
+    labels: ["dependencies", "docker"]
+    commit-message:
+      prefix: "chore(docker)"
+    groups:
+      docker-images:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "oven/bun"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "mcr.microsoft.com/playwright"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: terraform
     directory: /infra/bootstrap
     schedule:

--- a/.github/workflows/agent-verification.yml
+++ b/.github/workflows/agent-verification.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "tools/**"
       - "scripts/ci/**"
+      - "scripts/stack-check.sh"
       - "infra/compose/compose/dev.sh"
       - "infra/compose/scripts/pre-push.sh"
       - "apps/api/**"
@@ -24,7 +25,7 @@ jobs:
   verify:
     name: agent verification contract
     runs-on: ubuntu-24.04
-    timeout-minutes: 25
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
@@ -34,6 +35,7 @@ jobs:
             tooling:
               - 'tools/**'
               - 'scripts/ci/**'
+              - 'scripts/stack-check.sh'
               - 'infra/compose/compose/dev.sh'
               - 'infra/compose/scripts/pre-push.sh'
               - 'apps/api/**'

--- a/apps/docs/public/account-resource.json
+++ b/apps/docs/public/account-resource.json
@@ -64,7 +64,7 @@
     "Use the existing UI component/feature conventions. Scope every query key by accountId; capture accountId in mutations and invalidate that exact account's queries.",
     "Render loading, empty, error and permission-denied states. Translate visible labels into both locales. Do not put service authorization exclusively in the UI.",
     "Verify owner/admin mutations, member/viewer read access, revoked membership, cross-account reads and writes, forged ownership, and account-switch cache isolation.",
-    "Run feature verification. If intentional test additions change the inventory, explicitly run agent:inventory for the affected lanes, review its case diff, and rerun verification. Run release-local before claiming full local readiness. Report blockers and GitHub-only checks separately."
+    "Run feature verification. If intentional test additions change the inventory, preview agent:inventory for the affected lanes, review its case diff, apply --accept=<token> (plus --allow-removals=<token> for intentional removals), and rerun verification. Run release-local before claiming full local readiness. Report blockers and GitHub-only checks separately."
   ],
   "verificationProfile": "feature",
   "limitations": [

--- a/apps/docs/src/content/docs/recipes/add-account-resource.mdx
+++ b/apps/docs/src/content/docs/recipes/add-account-resource.mdx
@@ -26,6 +26,8 @@ The output includes schema, relations, service authorization using fresh members
 
 ## Complete the product behavior
 
+Before writing, the generator typechecks the complete prospective API program against its real tsconfig in memory. Both dry runs and generation reject semantic errors, missing imports and existing API type errors without writing generated files. Application lint and the remaining checks still run afterward.
+
 Generated scaffolding is a starting point. Add the approved fields and validation, then generate and review Drizzle SQL with `bun run db:generate` from `apps/api`. Use the [owned sandbox and sync command](/skills/verified-workflow/#regenerate-contracts-explicitly) to apply the migration and regenerate ACL/OpenAPI.
 
 Implement the UI using existing feature/component conventions and the generated API types:

--- a/apps/docs/src/content/docs/reference/agent-evaluation.mdx
+++ b/apps/docs/src/content/docs/reference/agent-evaluation.mdx
@@ -31,7 +31,11 @@ The reviewer copies only declared production integration files and appended Driz
 
 The same named API/UI/browser acceptance and app static checks run against that submission. This first judge does not support arbitrary resource names or task schemas. Security and release verification remain separate requirements.
 
-The candidate's application code still runs as the local user. Use an OS sandbox for untrusted submissions; file selection and disposable services are not a hostile-code boundary.
+Candidate execution runs automatically inside a non-root Docker container. Its root filesystem is read-only; writable temporary storage is bounded. It has no host bind mounts, Docker socket, inherited host credentials, published ports or outbound network. Disposable Postgres and Valkey share only the runner's private loopback namespace. CPU, memory and process limits apply.
+
+The trusted image is built from the reviewer's source and locked dependencies before candidate files are copied in. Candidate scripts, dependencies and configuration never control that build. Docker must be available; there is no fallback to executing a candidate on the host. The controller removes its containers and image tag on completion or failure. If cleanup fails, the command reports the run's resource names for inspection.
+
+This boundary protects the host. It does not make assertions running in the same process as arbitrary application code tamper-proof, and containers still share their Docker host's kernel. Continue reviewing candidate code and evidence. `agent:check:docker` includes real isolation probes and a complete positive candidate control.
 
 ## Measure agents separately
 

--- a/apps/docs/src/content/docs/skills/verified-workflow.mdx
+++ b/apps/docs/src/content/docs/skills/verified-workflow.mdx
@@ -67,13 +67,15 @@ This applies committed migrations to the owned sandbox, builds test templates an
 
 The ordinary API, UI and browser suites compare observed test identities, including multiplicity, with `tools/agent/inventories/*.json`. This rejects missing or substituted tests even when the reported total looks plausible.
 
-A complete passing underlying suite records an observation even when new tests cause an inventory mismatch. After reviewing the intended additions/removals, accept only the changed lanes:
+A complete passing underlying suite records an observation even when new tests cause an inventory mismatch. Preview only the changed lanes:
 
 ```sh
 bun run agent:inventory -- api.tests ui.tests ui.e2e
 ```
 
-Name fewer lanes when appropriate. Observations must belong to the unchanged checkout. Accept multiple changed lanes together, review the inventory diff against the actual tests, then rerun verification. Do not accept an unexpected shrink to obtain a green result. The security suite has its own [per-case manifest](/topics/security-spec/).
+The preview prints exact additions/removals and a review token without writing. Apply the reviewed diff with `--accept=<token>`. If it removes any case, also pass `--allow-removals=<token>`; this includes duplicate removal and same-count substitutions. Both approvals bind that exact checkout and diff, so changed observations or source invalidate them.
+
+Name fewer lanes when appropriate. Approve multiple changed lanes together, review the committed diff against the actual tests, then rerun verification. Do not approve an unexpected shrink to obtain a green result. The security suite has its own [per-case manifest](/topics/security-spec/).
 
 ## Tooling maintenance and boundaries
 
@@ -90,3 +92,9 @@ These tools execute reviewed source locally. Disposable databases do not isolate
 - [Add an account-owned resource](/recipes/add-account-resource/)
 - [Evaluate the tooling](/reference/agent-evaluation/)
 - [Executable security specification](/topics/security-spec/)
+
+## Root check completion
+
+`bun run check` exits 2 when required OpenAPI verification cannot run, 1 when a check fails, and 0 only when all declared checks complete. Start the API or set `OPENAPI_URL` and retry an incomplete check. Its declared scope is still smaller than the full release profile and GitHub gates.
+
+The owned API runs under Bun; Vite runs under Node with the UI package's supported Node version. Both bind to IPv4 loopback; readiness probes use IPv4 directly. The browser uses a localhost origin so secure development cookies work.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "sandbox:down": "bun tools/agent/sandbox/cli.ts down",
     "sandbox:inspect": "bun tools/agent/sandbox/cli.ts inspect",
     "agent:inspect": "bun tools/agent/inspect-cli.ts",
-    "agent:check:docker": "AGENT_DOCKER_TESTS=true bun test tools/agent/sandbox/lifecycle.test.ts",
+    "agent:check:docker": "AGENT_DOCKER_TESTS=true bun test tools/agent/sandbox/lifecycle.test.ts tools/agent/isolated.test.ts",
     "agent:eval": "bun tools/agent-evals/run.ts",
     "agent:sync": "bun tools/agent/sync-cli.ts",
     "agent:resource": "bun tools/agent/generate/cli.ts",

--- a/scripts/stack-check.sh
+++ b/scripts/stack-check.sh
@@ -71,7 +71,8 @@ fi
 
 if ((${#SKIPPED[@]} > 0)); then
   c_yellow "check incomplete: ${#SKIPPED[@]} check(s) skipped (${SKIPPED[*]})"
-  c_yellow "Legacy exit status retained; use agent:verify for strict OpenAPI evidence."
+  c_yellow "Start the API or set OPENAPI_URL, then rerun check."
+  exit 2
 else
   c_green "check passed (declared scope only; not the complete CI gate)"
 fi

--- a/tools/agent-evals/evaluation-runner.ts
+++ b/tools/agent-evals/evaluation-runner.ts
@@ -1,0 +1,156 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { now } from "../../apps/api/src/lib/time/now";
+import { identifyCheckout } from "../agent/checkout";
+import { planAccountResource } from "../agent/generate/account-resource";
+import { copyFixture } from "../agent/generate/fixture";
+import { formatEdits } from "../agent/generate/format";
+import type { IEdit } from "../agent/generate/patch";
+import { apply } from "../agent/generate/patch";
+import { runProcess } from "../agent/process";
+import type { ICheckResult } from "../agent/result";
+import {
+  downSandbox,
+  sandboxEnv,
+  upSandbox,
+  type ISandbox,
+} from "../agent/sandbox/lifecycle";
+import { evaluateApi } from "./api-evaluation";
+import type { IEvaluationContext } from "./evaluation.types";
+import { evaluateMigration } from "./migration-evaluation";
+import { candidateEdits, migrationEdits } from "./submission";
+import { evaluateUi } from "./ui-evaluation";
+
+const NO_ENV_FILE = "--no-env-file";
+
+const API_DIRECTORY = "apps/api";
+
+export async function runEvaluation(
+  root: string,
+  candidate?: string,
+  externalSandbox?: ISandbox
+): Promise<number> {
+  const dir = mkdtempSync(join(tmpdir(), "bs-eval-"));
+  let sandbox: ISandbox | undefined;
+  const results: ICheckResult[] = [];
+  const evidenceDir = mkdtempSync(join(tmpdir(), "bs-evidence-"));
+  const startedAt = now();
+  const checkout = identifyCheckout(root);
+
+  try {
+    copyFixture(root, dir);
+    const apiEdits = await formatEdits(
+      dir,
+      planAccountResource(dir, "Projects", "team-read-admin-write")
+    );
+    const submitted =
+      candidate !== undefined
+        ? new Map(
+            candidateEdits(candidate, apiEdits).map((plannedEdit) => [
+              plannedEdit.path,
+              plannedEdit,
+            ])
+          )
+        : new Map<string, IEdit>();
+
+    apply(
+      dir,
+      apiEdits.map(
+        (plannedEdit) => submitted.get(plannedEdit.path) ?? plannedEdit
+      )
+    );
+
+    if (candidate !== undefined) {
+      apply(dir, migrationEdits(dir, candidate));
+    }
+
+    sandbox = externalSandbox ?? (await upSandbox(root));
+    const env = sandboxEnv(sandbox);
+
+    for (const script of [
+      ...(candidate !== undefined ? [] : ["db:generate"]),
+      "db:migrate",
+      "build:templates",
+    ]) {
+      const run = await runProcess(
+        [process.execPath, NO_ENV_FILE, "run", script],
+        { cwd: join(dir, API_DIRECTORY), env }
+      );
+
+      if (run.code !== 0) {
+        throw new Error("Fixture prerequisite failed");
+      }
+    }
+
+    const context: IEvaluationContext = {
+      root,
+      dir,
+      evidenceDir,
+      candidate,
+      env,
+      results,
+      sandbox,
+    };
+
+    await evaluateApi(context);
+    await evaluateUi(context);
+
+    if (candidate === undefined) {
+      await evaluateMigration(context);
+    }
+  } catch (error) {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : "Evaluation failed"}\n`
+    );
+    results.push({
+      checkId: "eval.prerequisites",
+      status: "blocked",
+      reason: "evaluation_prerequisite_failed",
+    });
+  } finally {
+    if (sandbox && externalSandbox === undefined) {
+      await downSandbox(root, sandbox.id).catch(() => {
+        results.push({
+          checkId: "eval.cleanup",
+          status: "blocked",
+          reason: "cleanup_required",
+        });
+      });
+    }
+
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(evidenceDir, { recursive: true, force: true });
+  }
+
+  if (identifyCheckout(root).fingerprint !== checkout.fingerprint) {
+    results.push({
+      checkId: "checkout.stable",
+      status: "blocked",
+      reason: "checkout_changed",
+    });
+  }
+
+  const status = results.some((check) => check.status === "blocked")
+    ? "blocked"
+    : results.some((check) => check.status === "failed")
+      ? "failed"
+      : "passed";
+
+  console.log(
+    JSON.stringify({
+      schemaVersion: 1,
+      runId: crypto.randomUUID(),
+      startedAt,
+      finishedAt: now(),
+      checkout,
+      kind:
+        candidate !== undefined ? "candidate-review" : "deterministic-judge",
+      status,
+      checks: results,
+      liveAgentRuns: 0,
+    })
+  );
+
+  return status === "passed" ? 0 : status === "failed" ? 1 : 2;
+}

--- a/tools/agent-evals/isolated/Dockerfile
+++ b/tools/agent-evals/isolated/Dockerfile
@@ -1,0 +1,12 @@
+FROM oven/bun:1.4.0-debian@sha256:5bb0f9be3a1a36a03e27c9a9dd894a3b1ad26657155c7df4dda771e17bf872ef AS bun
+FROM mcr.microsoft.com/playwright:v1.62.1-noble@sha256:dcc5531e97840b9b5e794f2814476b21571c5124a3fca2267d73041f56e7580e
+COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
+WORKDIR /review
+COPY apps/api/package.json apps/api/bun.lock apps/api/
+COPY apps/ui/package.json apps/ui/bun.lock apps/ui/
+RUN cd apps/api && bun install --frozen-lockfile --ignore-scripts && cd ../ui && bun install --frozen-lockfile --ignore-scripts
+COPY . .
+RUN git init -q && git add . && git -c user.name=Verifier -c user.email=verifier@example.com commit -qm snapshot && git config --system safe.directory /review
+USER 1000:1000
+ENV HOME=/tmp
+CMD ["sleep", "infinity"]

--- a/tools/agent-evals/isolated/SECURITY.md
+++ b/tools/agent-evals/isolated/SECURITY.md
@@ -1,0 +1,42 @@
+# Candidate execution boundary
+
+This controller protects the local machine while evaluating a supplied Projects
+implementation. The trusted inputs are the reviewing checkout, its pinned images,
+locked dependencies, Docker installation and operating-system kernel. Candidate
+source and appended migration artifacts are untrusted inputs.
+
+## Authority and data flow
+
+| Boundary          | Allowed authority                                                         | Excluded authority                                                              |
+| ----------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Image preparation | Reviewer-selected source and locked dependency installation               | Candidate scripts, dependencies, Dockerfiles and configuration                  |
+| Source intake     | Regular files in the declared API/UI surface and append-only migrations   | Symlinks, removed/rewritten migration history, arbitrary files                  |
+| Candidate runtime | Non-root process, bounded temporary filesystem, private loopback services | Host mounts, Docker socket, host credentials, outbound network, published ports |
+| Result collection | Bounded stdout/stderr and process completion                              | Candidate-provided test expectations                                            |
+| Cleanup           | Containers and image tag named for this random run                        | Global Docker pruning or shared development services                            |
+
+The candidate runner has a read-only root, all Linux capabilities dropped,
+`no-new-privileges`, process/memory/CPU limits and bounded tmpfs. Postgres and
+Valkey run in separate containers sharing only its network namespace. No external
+network is attached, so candidate application code can reach its disposable
+services but cannot use the host network or internet. Both services use fresh
+credentials. Input is streamed into tmpfs; no host source directory is mounted.
+
+The live integration test checks the effective UID, capability and privilege
+settings, absence of host paths and the Docker socket, absence of external routes,
+and denial of writes to the reviewing source. A positive control must still
+complete API, UI and browser acceptance inside the same restrictions. A policy
+unit test checks that host mounts and privileged execution cannot enter the launch
+arguments unnoticed.
+
+## Limits
+
+Container isolation shares Docker's kernel and is not a separate virtual-machine
+boundary on native Linux. Keep Docker and its host patched. Resource limits bound
+this run, not every workload on the machine. A forcibly killed controller or an
+unavailable Docker daemon can require manual cleanup of the reported run names.
+
+Application code executes inside test processes and can influence their behavior.
+This boundary protects the host; it does not prove assertions are immune to
+malicious same-process code. Review code and evidence independently. Deterministic
+mutation tests validate the judge separately from arbitrary candidate runs.

--- a/tools/agent-evals/isolated/candidate.ts
+++ b/tools/agent-evals/isolated/candidate.ts
@@ -1,0 +1,84 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { planAccountResource } from "../../agent/generate/account-resource";
+import { planReferenceUi } from "../../agent/generate/reference-ui";
+import { runProcess } from "../../agent/process";
+import { candidateEdits, migrationEdits } from "../submission";
+import { candidateOutcome } from "./outcome";
+import { sendInput } from "./input";
+import { withIsolatedRuntime } from "./runtime";
+
+/** Copy only declared source bytes, never candidate dependencies, scripts, configuration or symlinks. */
+export function stageCandidate(
+  root: string,
+  candidate: string,
+  destination: string
+): void {
+  const edits = [
+    ...candidateEdits(
+      candidate,
+      planAccountResource(root, "Projects", "team-read-admin-write")
+    ),
+    ...candidateEdits(candidate, planReferenceUi(root)),
+    ...migrationEdits(root, candidate),
+  ];
+
+  if (
+    edits.length > 1000 ||
+    edits.reduce(
+      (bytes, plannedEdit) => bytes + Buffer.byteLength(plannedEdit.after),
+      0
+    ) >
+      32 * 1024 * 1024
+  ) {
+    throw new Error("Candidate exceeds submission budget");
+  }
+
+  for (const plannedEdit of edits) {
+    const path = join(destination, plannedEdit.path);
+
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, plannedEdit.after, { mode: 0o644 });
+  }
+}
+
+export async function runIsolatedCandidate(
+  root: string,
+  candidate: string
+): Promise<number> {
+  const input = mkdtempSync(join(tmpdir(), "bs-candidate-input-"));
+
+  try {
+    stageCandidate(root, candidate, join(input, "candidate"));
+
+    return await withIsolatedRuntime(root, async ({ name, state }) => {
+      writeFileSync(join(input, "sandbox.json"), JSON.stringify(state), {
+        mode: 0o644,
+      });
+      sendInput(name, input);
+      const result = await runProcess(
+        [
+          "docker",
+          "exec",
+          name,
+          "bun",
+          "--no-env-file",
+          "/review/tools/agent-evals/isolated/worker.ts",
+        ],
+        { cwd: root, timeoutMs: 900_000 }
+      );
+
+      if (result.status !== "completed") {
+        throw new Error("Isolated candidate execution did not complete");
+      }
+
+      process.stdout.write(result.stdout);
+      process.stderr.write(result.stderr);
+
+      return candidateOutcome(result.stdout, result.code);
+    });
+  } finally {
+    rmSync(input, { recursive: true, force: true });
+  }
+}

--- a/tools/agent-evals/isolated/control.fixture.ts
+++ b/tools/agent-evals/isolated/control.fixture.ts
@@ -1,0 +1,40 @@
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { copyFixture } from "../../agent/generate/fixture";
+import { planAccountResource } from "../../agent/generate/account-resource";
+import { planReferenceUi } from "../../agent/generate/reference-ui";
+import { formatEdits, formatUiEdits } from "../../agent/generate/format";
+import { apply } from "../../agent/generate/patch";
+import { runProcess } from "../../agent/process";
+
+/** Build a trusted positive control for the container integration test. */
+export async function prepareControl(): Promise<void> {
+  const candidate = "/tmp/input/candidate";
+
+  copyFixture("/review", candidate);
+  apply(
+    candidate,
+    await formatEdits(
+      candidate,
+      planAccountResource(candidate, "Projects", "team-read-admin-write")
+    )
+  );
+  apply(candidate, await formatUiEdits(candidate, planReferenceUi(candidate)));
+  const migration = await runProcess(
+    [process.execPath, "--no-env-file", "run", "db:generate"],
+    { cwd: join(candidate, "apps/api") }
+  );
+
+  if (migration.status !== "completed" || migration.code !== 0) {
+    throw new Error(
+      `Control migration generation failed\n${migration.stderr.slice(-4000)}`
+    );
+  }
+
+  for (const app of ["api", "ui"]) {
+    rmSync(join(candidate, "apps", app, "node_modules"), {
+      recursive: true,
+      force: true,
+    });
+  }
+}

--- a/tools/agent-evals/isolated/docker.ts
+++ b/tools/agent-evals/isolated/docker.ts
@@ -1,0 +1,38 @@
+import { runProcess } from "../../agent/process";
+
+export async function docker(
+  root: string,
+  args: string[],
+  timeoutMs = 120_000
+): Promise<string> {
+  const result = await runProcess(["docker", ...args], {
+    cwd: root,
+    timeoutMs,
+  });
+
+  if (result.status !== "completed" || result.code !== 0) {
+    throw new Error(
+      `Candidate sandbox Docker operation failed: ${args[0] ?? "unknown"} (${result.reason})\n${result.stderr.slice(-4000)}`
+    );
+  }
+
+  return result.stdout.trim();
+}
+
+/** A partially created run may have no container; other cleanup failures remain visible. */
+export async function removeContainer(
+  root: string,
+  name: string
+): Promise<void> {
+  const result = await runProcess(["docker", "rm", "-f", "-v", name], {
+    cwd: root,
+    timeoutMs: 120_000,
+  });
+
+  if (
+    result.status !== "completed" ||
+    (result.code !== 0 && !result.stderr.includes("No such container"))
+  ) {
+    throw new Error(`Candidate container cleanup failed: ${name}`);
+  }
+}

--- a/tools/agent-evals/isolated/docker.ts
+++ b/tools/agent-evals/isolated/docker.ts
@@ -12,7 +12,7 @@ export async function docker(
 
   if (result.status !== "completed" || result.code !== 0) {
     throw new Error(
-      `Candidate sandbox Docker operation failed: ${args[0] ?? "unknown"} (${result.reason})\n${result.stderr.slice(-4000)}`
+      `Candidate sandbox Docker operation failed (${result.reason}; exit=${String(result.code)})`
     );
   }
 

--- a/tools/agent-evals/isolated/input.ts
+++ b/tools/agent-evals/isolated/input.ts
@@ -1,0 +1,35 @@
+import { execFileSync } from "node:child_process";
+
+/** Stream reviewed files into tmpfs through exec; no bind mount exposes a host directory. */
+export function sendInput(name: string, directory: string): void {
+  execFileSync("docker", ["exec", name, "mkdir", "-p", "/tmp/input"], {
+    timeout: 30_000,
+  });
+  const archive = execFileSync(
+    "tar",
+    ["--format=ustar", "-C", directory, "-cf", "-", "."],
+    {
+      timeout: 30_000,
+      maxBuffer: 40 * 1024 * 1024,
+    }
+  );
+
+  execFileSync(
+    "docker",
+    [
+      "exec",
+      "-i",
+      name,
+      "tar",
+      "--no-same-owner",
+      "-xf",
+      "-",
+      "-C",
+      "/tmp/input",
+    ],
+    {
+      input: archive,
+      timeout: 30_000,
+    }
+  );
+}

--- a/tools/agent-evals/isolated/outcome.ts
+++ b/tools/agent-evals/isolated/outcome.ts
@@ -1,0 +1,57 @@
+import { isRecord } from "../../agent/validation";
+
+const REQUIRED_CHECKS = [
+  "submission",
+  "ui-known-good",
+  "api.check",
+  "ui.check",
+  "projects.browser",
+];
+
+/** Process success alone cannot certify a candidate; require complete reviewer evidence too. */
+export function candidateOutcome(stdout: string, exit: number | null): number {
+  const line = stdout.trim().split("\n").at(-1);
+  let value: unknown;
+
+  try {
+    value = JSON.parse(line ?? "");
+  } catch {
+    return 2;
+  }
+
+  if (
+    !isRecord(value) ||
+    value.schemaVersion !== 1 ||
+    value.kind !== "candidate-review" ||
+    !Array.isArray(value.checks)
+  ) {
+    return 2;
+  }
+
+  const checks: unknown[] = value.checks;
+
+  if (
+    checks.length !== REQUIRED_CHECKS.length ||
+    !REQUIRED_CHECKS.every(
+      (id) =>
+        checks.filter(
+          (check) =>
+            isRecord(check) &&
+            check.checkId === id &&
+            (check.status === "passed" || check.status === "failed")
+        ).length === 1
+    )
+  ) {
+    return 2;
+  }
+
+  const failed = checks.some(
+    (check) => isRecord(check) && check.status === "failed"
+  );
+
+  if (exit === 0 && value.status === "passed" && !failed) {
+    return 0;
+  }
+
+  return exit === 1 && value.status === "failed" && failed ? 1 : 2;
+}

--- a/tools/agent-evals/isolated/policy.ts
+++ b/tools/agent-evals/isolated/policy.ts
@@ -1,0 +1,29 @@
+/** Candidate code receives a private network namespace and no host mounts or inherited environment. */
+export function runnerArguments(name: string, image: string): string[] {
+  return [
+    "run",
+    "-d",
+    "--name",
+    name,
+    "--network",
+    "none",
+    "--read-only",
+    "--cap-drop",
+    "ALL",
+    "--security-opt",
+    "no-new-privileges",
+    "--user",
+    "1000:1000",
+    "--pids-limit",
+    "512",
+    "--memory",
+    "8g",
+    "--cpus",
+    "4",
+    "--tmpfs",
+    "/tmp:rw,exec,nosuid,nodev,size=4g,mode=1777",
+    "--shm-size",
+    "256m",
+    image,
+  ];
+}

--- a/tools/agent-evals/isolated/runtime.ts
+++ b/tools/agent-evals/isolated/runtime.ts
@@ -1,0 +1,193 @@
+import { now } from "../../../apps/api/src/lib/time/now";
+import { requireValue } from "../../agent/validation";
+import { randomBytes } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { copySource } from "../../agent/generate/fixture";
+import { selectImage, type ISandbox } from "../../agent/sandbox/lifecycle";
+import { docker, removeContainer } from "./docker";
+import { runnerArguments } from "./policy";
+
+export interface IIsolatedRuntime {
+  name: string;
+  state: ISandbox;
+}
+
+/** The controller owns Docker; candidate code has neither its socket nor a network route to it. */
+export async function withIsolatedRuntime(
+  root: string,
+  run: (runtime: IIsolatedRuntime) => Promise<number>
+): Promise<number> {
+  const id = randomBytes(16).toString("hex");
+  const name = `bs-candidate-${id}`;
+  const image = `bs-candidate:${id}`;
+  const source = mkdtempSync(join(tmpdir(), "bs-candidate-build-"));
+  const state: ISandbox = {
+    version: 1,
+    id,
+    owner: id,
+    root: "/review",
+    createdAt: now(),
+    password: randomBytes(24).toString("hex"),
+    valkeyPassword: randomBytes(24).toString("hex"),
+    postgres: `${name}-pg`,
+    valkey: `${name}-valkey`,
+    postgresPort: 5432,
+    valkeyPort: 6379,
+  };
+  const pins = [
+    ...readFileSync(
+      join(root, ".github/workflows/apps-api-ci.yml"),
+      "utf8"
+    ).matchAll(/^\s*image:\s*(\S+)\s*$/gm),
+  ].map((match) => match[1] ?? "");
+
+  let outcome: number | undefined;
+  let failure: unknown;
+
+  try {
+    copySource(root, source);
+    await docker(
+      root,
+      [
+        "build",
+        "-f",
+        "tools/agent-evals/isolated/Dockerfile",
+        "-t",
+        image,
+        source,
+      ],
+      900_000
+    );
+    await docker(root, runnerArguments(name, image));
+    await docker(root, [
+      "run",
+      "-d",
+      "--name",
+      state.postgres,
+      "--network",
+      `container:${name}`,
+      "--read-only",
+      "--cap-drop",
+      "ALL",
+      "--security-opt",
+      "no-new-privileges",
+      "--user",
+      "postgres",
+      "--pids-limit",
+      "128",
+      "--memory",
+      "1g",
+      "--cpus",
+      "1",
+      "--tmpfs",
+      "/var/lib/postgresql/data:rw,nosuid,nodev,size=512m,mode=1777",
+      "--tmpfs",
+      "/var/run/postgresql:rw,nosuid,nodev,mode=1777",
+      "--tmpfs",
+      "/tmp:rw,nosuid,nodev,size=64m,mode=1777",
+      "-e",
+      "PGDATA=/var/lib/postgresql/data/pgdata",
+      "-e",
+      "POSTGRES_USER=app",
+      "-e",
+      `POSTGRES_PASSWORD=${state.password}`,
+      "-e",
+      "POSTGRES_DB=app",
+      selectImage(pins, "postgres"),
+    ]);
+    await docker(root, [
+      "run",
+      "-d",
+      "--name",
+      state.valkey,
+      "--network",
+      `container:${name}`,
+      "--read-only",
+      "--cap-drop",
+      "ALL",
+      "--security-opt",
+      "no-new-privileges",
+      "--user",
+      "valkey",
+      "--pids-limit",
+      "64",
+      "--memory",
+      "256m",
+      "--cpus",
+      "1",
+      selectImage(pins, "valkey/valkey"),
+      "valkey-server",
+      "--save",
+      "",
+      "--appendonly",
+      "no",
+      "--requirepass",
+      state.valkeyPassword,
+    ]);
+
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await docker(root, [
+          "exec",
+          "-e",
+          `PGPASSWORD=${state.password}`,
+          state.postgres,
+          "psql",
+          "-h",
+          "127.0.0.1",
+          "-U",
+          "app",
+          "-d",
+          "app",
+          "-c",
+          "SELECT 1",
+        ]);
+        await docker(root, [
+          "exec",
+          state.valkey,
+          "valkey-cli",
+          "-a",
+          state.valkeyPassword,
+          "ping",
+        ]);
+        break;
+      } catch {
+        if (attempt >= 60) {
+          throw new Error("Candidate sandbox services did not become ready");
+        }
+
+        await Bun.sleep(250);
+      }
+    }
+
+    outcome = await run({ name, state });
+  } catch (error) {
+    failure = error;
+  } finally {
+    const results = await Promise.allSettled(
+      [state.postgres, state.valkey, name].map((container) =>
+        removeContainer(root, container)
+      )
+    );
+
+    await docker(root, ["image", "rm", image]).catch(() => undefined);
+    rmSync(source, { recursive: true, force: true });
+
+    if (results.some((result) => result.status === "rejected")) {
+      failure = new Error(
+        `Candidate sandbox cleanup requires inspection: ${name}`,
+        { cause: failure }
+      );
+    }
+  }
+
+  if (failure !== undefined) {
+    throw failure instanceof Error
+      ? failure
+      : new Error("Candidate sandbox failed", { cause: failure });
+  }
+
+  return requireValue(outcome, "Candidate sandbox produced no outcome");
+}

--- a/tools/agent-evals/isolated/worker.ts
+++ b/tools/agent-evals/isolated/worker.ts
@@ -1,0 +1,44 @@
+import { existsSync, readFileSync } from "node:fs";
+import { runEvaluation } from "../evaluation-runner";
+import type { ISandbox } from "../../agent/sandbox/lifecycle";
+import { parseRecord } from "../../agent/validation";
+
+if (
+  !existsSync("/.dockerenv") ||
+  process.getuid?.() !== 1000 ||
+  existsSync("/var/run/docker.sock")
+) {
+  throw new Error(
+    "This worker must run through the isolated candidate controller"
+  );
+}
+
+const descriptor = parseRecord(readFileSync("/tmp/input/sandbox.json", "utf8"));
+
+if (
+  typeof descriptor.password !== "string" ||
+  typeof descriptor.valkeyPassword !== "string" ||
+  typeof descriptor.id !== "string"
+) {
+  throw new Error("Invalid isolated service descriptor");
+}
+
+const state: ISandbox = {
+  version: 1,
+  id: descriptor.id,
+  owner: descriptor.id,
+  root: "/review",
+  createdAt: "isolated",
+  password: descriptor.password,
+  valkeyPassword: descriptor.valkeyPassword,
+  postgres: "isolated-postgres",
+  valkey: "isolated-valkey",
+  postgresPort: 5432,
+  valkeyPort: 6379,
+};
+
+process.exitCode = await runEvaluation(
+  "/review",
+  "/tmp/input/candidate",
+  state
+);

--- a/tools/agent-evals/run.ts
+++ b/tools/agent-evals/run.ts
@@ -1,162 +1,24 @@
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { now } from "../../apps/api/src/lib/time/now";
-import { identifyCheckout } from "../agent/checkout";
-import { planAccountResource } from "../agent/generate/account-resource";
-import { copyFixture } from "../agent/generate/fixture";
-import { formatEdits } from "../agent/generate/format";
-import type { IEdit } from "../agent/generate/patch";
-import { apply } from "../agent/generate/patch";
-import { runProcess } from "../agent/process";
-import type { ICheckResult } from "../agent/result";
-import {
-  downSandbox,
-  sandboxEnv,
-  upSandbox,
-  type ISandbox,
-} from "../agent/sandbox/lifecycle";
-import { evaluateApi } from "./api-evaluation";
-import type { IEvaluationContext } from "./evaluation.types";
-import { evaluateMigration } from "./migration-evaluation";
-import { candidateEdits, migrationEdits } from "./submission";
-import { evaluateUi } from "./ui-evaluation";
+import { runEvaluation } from "./evaluation-runner";
+import { runIsolatedCandidate } from "./isolated/candidate";
 
-const NO_ENV_FILE = "--no-env-file";
-
-const API_DIRECTORY = "apps/api";
 const root = fileURLToPath(new URL("../../", import.meta.url));
-const dir = mkdtempSync(join(tmpdir(), "bs-eval-"));
-let sandbox: ISandbox | undefined;
-const results: ICheckResult[] = [];
-const evidenceDir = mkdtempSync(join(tmpdir(), "bs-evidence-"));
-const startedAt = now();
-const checkout = identifyCheckout(root);
+const args = process.argv.slice(2).filter((arg) => arg !== "--");
 
 try {
-  const args = process.argv.slice(2);
-  const candidate =
-    args.length === 1 && args[0]?.startsWith("--candidate=") === true
-      ? args[0].slice(12)
-      : undefined;
-
-  if (candidate === undefined && args.join(" ") !== "--deterministic") {
+  if (args.length === 1 && args[0] === "--deterministic") {
+    process.exitCode = await runEvaluation(root);
+  } else if (
+    args.length === 1 &&
+    args[0]?.startsWith("--candidate=") === true
+  ) {
+    process.exitCode = await runIsolatedCandidate(root, args[0].slice(12));
+  } else {
     throw new Error("Use --deterministic or --candidate=/absolute/checkout");
   }
-
-  copyFixture(root, dir);
-  const apiEdits = await formatEdits(
-    dir,
-    planAccountResource(dir, "Projects", "team-read-admin-write")
-  );
-  const submitted =
-    candidate !== undefined
-      ? new Map(
-          candidateEdits(candidate, apiEdits).map((plannedEdit) => [
-            plannedEdit.path,
-            plannedEdit,
-          ])
-        )
-      : new Map<string, IEdit>();
-
-  apply(
-    dir,
-    apiEdits.map(
-      (plannedEdit) => submitted.get(plannedEdit.path) ?? plannedEdit
-    )
-  );
-
-  if (candidate !== undefined) {
-    apply(dir, migrationEdits(dir, candidate));
-  }
-
-  sandbox = await upSandbox(root);
-  const env = sandboxEnv(sandbox);
-
-  for (const script of [
-    ...(candidate !== undefined ? [] : ["db:generate"]),
-    "db:migrate",
-    "build:templates",
-  ]) {
-    const run = await runProcess(
-      [process.execPath, NO_ENV_FILE, "run", script],
-      { cwd: join(dir, API_DIRECTORY), env }
-    );
-
-    if (run.code !== 0) {
-      throw new Error("Fixture prerequisite failed");
-    }
-  }
-
-  const context: IEvaluationContext = {
-    root,
-    dir,
-    evidenceDir,
-    candidate,
-    env,
-    results,
-    sandbox,
-  };
-
-  await evaluateApi(context);
-  await evaluateUi(context);
-
-  if (candidate === undefined) {
-    await evaluateMigration(context);
-  }
 } catch (error) {
-  process.stderr.write(
-    `${error instanceof Error ? error.message : "Evaluation failed"}\n`
+  console.error(
+    error instanceof Error ? error.message : "Evaluation unavailable"
   );
-  results.push({
-    checkId: "eval.prerequisites",
-    status: "blocked",
-    reason: "evaluation_prerequisite_failed",
-  });
-} finally {
-  if (sandbox) {
-    await downSandbox(root, sandbox.id).catch(() => {
-      results.push({
-        checkId: "eval.cleanup",
-        status: "blocked",
-        reason: "cleanup_required",
-      });
-    });
-  }
-
-  rmSync(dir, { recursive: true, force: true });
-  rmSync(evidenceDir, { recursive: true, force: true });
+  process.exitCode = 2;
 }
-
-if (identifyCheckout(root).fingerprint !== checkout.fingerprint) {
-  results.push({
-    checkId: "checkout.stable",
-    status: "blocked",
-    reason: "checkout_changed",
-  });
-}
-
-const status = results.some((check) => check.status === "blocked")
-  ? "blocked"
-  : results.some((check) => check.status === "failed")
-    ? "failed"
-    : "passed";
-
-console.log(
-  JSON.stringify({
-    schemaVersion: 1,
-    runId: crypto.randomUUID(),
-    startedAt,
-    finishedAt: now(),
-    checkout,
-    kind:
-      process.argv[2]?.startsWith("--candidate=") === true
-        ? "candidate-review"
-        : "deterministic-judge",
-    status,
-    checks: results,
-    liveAgentRuns: 0,
-  })
-);
-process.exitCode = status === "passed" ? 0 : status === "failed" ? 1 : 2;

--- a/tools/agent-evals/submission.ts
+++ b/tools/agent-evals/submission.ts
@@ -48,15 +48,27 @@ export function candidateEdits(
     }));
 }
 
+function migrationPaths(base: string): string[] {
+  const paths: string[] = [];
+
+  for (const path of new Bun.Glob("**/*.{sql,json}").scanSync({
+    cwd: join(base, "apps/api/drizzle"),
+    followSymlinks: false,
+  })) {
+    if (paths.length >= 1000) {
+      throw new Error("Candidate exceeds migration file budget");
+    }
+
+    paths.push(path);
+  }
+
+  return paths;
+}
+
 /** Existing migration history must be byte-identical; only appended migration artifacts are accepted. */
 export function migrationEdits(root: string, candidate: string): IEdit[] {
   const base = realpathSync(candidate);
-  const paths = [
-    ...new Bun.Glob("**/*.{sql,json}").scanSync({
-      cwd: join(base, "apps/api/drizzle"),
-      followSymlinks: false,
-    }),
-  ];
+  const paths = migrationPaths(base);
   const existing = [
     ...new Bun.Glob("**/*.{sql,json}").scanSync({
       cwd: join(root, "apps/api/drizzle"),
@@ -68,6 +80,7 @@ export function migrationEdits(root: string, candidate: string): IEdit[] {
   }
 
   const edits: IEdit[] = [];
+  let bytes = 0;
 
   for (const path of paths) {
     const relativePath = `apps/api/drizzle/${path}`;
@@ -83,6 +96,12 @@ export function migrationEdits(root: string, candidate: string): IEdit[] {
     }
 
     const after = readCandidate(base, relativePath);
+
+    bytes += Buffer.byteLength(after);
+
+    if (bytes > 32 * 1024 * 1024) {
+      throw new Error("Candidate exceeds migration byte budget");
+    }
 
     if (before !== null && path !== "meta/_journal.json" && before !== after) {
       throw new Error("Candidate rewrites migration history");

--- a/tools/agent-evals/ui-evaluation.ts
+++ b/tools/agent-evals/ui-evaluation.ts
@@ -22,8 +22,7 @@ async function evaluateBrowser(
   const browserReport = join(evidenceDir, "browser.xml");
   const browser = await runProcess(
     [
-      process.execPath,
-      NO_ENV_FILE,
+      "node",
       "node_modules/@playwright/test/cli.js",
       "test",
       "projects.spec.ts",
@@ -37,6 +36,12 @@ async function evaluateBrowser(
       timeoutMs: 180000,
     }
   );
+
+  if (browser.code !== 0) {
+    console.error(
+      `Browser runner failed (exit=${String(browser.code)}): ${browser.stderr.slice(-4000)}\n${browser.stdout.slice(-8000)}`
+    );
+  }
 
   results.push(
     testEvidence(

--- a/tools/agent/README.md
+++ b/tools/agent/README.md
@@ -59,7 +59,7 @@ bun run agent:resource Projects --scope=account --policy=team-read-admin-write -
 bun run agent:resource Projects --scope=account --policy=team-read-admin-write --json
 ```
 
-The new opt-in mode generates schema, relations, explicit owner/admin write and member/viewer read permissions, fresh-membership service authorization, tenant predicates, request ownership rejection, routes, audit events and real HTTP tests. It checks every patch target before writing and refuses ambiguous anchors, conflicts and symlink targets. A generator lease coordinates simultaneous invocations, and each file is replaced atomically. On failure it restores its own unchanged writes; it preserves subsequent editor changes. If a process is killed during generation, inspect the diff for partial edits. `bun run agent:recover -- generator --acknowledge-partial-writes` and the equivalent `checkout` command remove only locks whose PID is dead; live or malformed locks are refused. Recovery never rolls back edits blindly. Review the dry-run path list. The legacy app-local user-scoped invocation remains available. Account generation is dispatched at the root; the API app does not import root tooling.
+The new opt-in mode generates schema, relations, explicit owner/admin write and member/viewer read permissions, fresh-membership service authorization, tenant predicates, request ownership rejection, routes, audit events and real HTTP tests. It checks every patch target before writing and refuses ambiguous anchors, conflicts and symlink targets. Before writing, the account-resource CLI typechecks the full prospective API program using an in-memory overlay of the generated files and the real API tsconfig. Missing imports and semantic errors block both generation and dry runs without touching the checkout. Existing API type errors must also be fixed first. The full application check remains required for lint and other contracts. A generator lease coordinates simultaneous invocations, and each file is replaced atomically. On failure it restores its own unchanged writes; it preserves subsequent editor changes. If a process is killed during generation, inspect the diff for partial edits. `bun run agent:recover -- generator --acknowledge-partial-writes` and the equivalent `checkout` command remove only locks whose PID is dead; live or malformed locks are refused. Recovery never rolls back edits blindly. Review the dry-run path list. The legacy app-local user-scoped invocation remains available. Account generation is dispatched at the root; the API app does not import root tooling.
 
 Generate SQL with the existing `db:generate` command; apply it through an owned verification sandbox. Run `bun run agent:sync -- --sandbox=<id> --json` from the root to apply the committed migrations, build test templates and regenerate ACL/OpenAPI through this checkout’s private runtime. This explicit write command reports the contract paths to review; verification itself remains read-only for committed contracts. The list has a deliberate 100-record bound; choose a pagination contract before growing it. Audit writes retain the stack's existing best-effort convention; this does not add a durable outbox. Naming supports simple plural PascalCase, not English inflection.
 
@@ -80,9 +80,9 @@ Task prompts for Projects, a description migration, and a tenant fix are in `too
 
 `agent:check` covers protocol failures, real OpenAPI generation, subprocess deadlines, recipe drift, patch conflicts and repeat generation. `agent:check:docker` proves isolation and scoped cleanup. The always-reporting PR workflow runs tooling tests and deterministic integration checks when relevant paths change. Existing API/UI/security gates remain separate.
 
-`bun run check` keeps its lightweight compatibility behavior but says `check incomplete` when OpenAPI was skipped. It cannot substitute for `agent:verify --profile=release-local` or the complete GitHub checks.
+`bun run check` returns 2 (incomplete) when required OpenAPI verification is unavailable, 1 when a check fails, and 0 only when all checks in its declared scope complete. Start the API or set `OPENAPI_URL` before rerunning. It still cannot substitute for `agent:verify --profile=release-local` or the complete GitHub checks.
 
-To review an independently implemented Projects checkout, run `bun run agent:eval -- --candidate=/absolute/path/to/checkout`. The reviewer copies only the declared production integration files and appended Drizzle artifacts into its own fixture. Existing migration history must match. Candidate tests, scripts, CI and evaluator files are excluded; candidate files must be regular files within that checkout. Candidate mode does not generate missing SQL for the submission. Dependencies are copied into each fixture (copy-on-write where supported), not symlinked into the reviewer checkout. Evidence is written to a separate private temporary directory. These reduce accidental interference; same-user hostile code still requires an OS sandbox. Candidate mode runs acceptance against arbitrary implementations, while the separate deterministic run validates the judge against deliberate defects. It runs the same named API/UI/browser acceptance and generated-checkout API/UI static checks; the broader security and release profiles remain required separately. Alternate resource names and arbitrary task schemas are not accepted by this first concrete judge.
+To review an independently implemented Projects checkout, run `bun run agent:eval -- --candidate=/absolute/path/to/checkout`. The reviewer copies only the declared production integration files and appended Drizzle artifacts into its own fixture. Existing migration history must match. Candidate tests, scripts, CI and evaluator files are excluded; candidate files must be regular files within that checkout. Candidate mode does not generate missing SQL for the submission. Dependencies are copied into each fixture (copy-on-write where supported), not symlinked into the reviewer checkout. Evidence is written to a separate private temporary directory. Candidate execution runs in a non-root Docker container with a read-only root, no host mounts, no Docker socket, no inherited host credentials and no external network. Disposable Postgres and Valkey share only its loopback network namespace. CPU, memory, process and temporary-storage limits apply. Image preparation installs the reviewer’s locked dependencies before any candidate source enters the runtime. The controller removes its containers and image tag after completion or failure. Container isolation protects the host; it does not make a same-process test runner tamper-proof against application code. Review the candidate and evidence independently. Candidate mode runs acceptance against arbitrary implementations, while the separate deterministic run validates the judge against deliberate defects. It runs the same named API/UI/browser acceptance and generated-checkout API/UI static checks; the broader security and release profiles remain required separately. Alternate resource names and arbitrary task schemas are not accepted by this first concrete judge.
 
 The desired repository settings list `agent verification contract` as required. This change does not apply GitHub settings remotely; let the new workflow report before reconciling those settings.
 
@@ -100,12 +100,22 @@ observation even if its inventory disagrees. Then explicitly run:
 bun run agent:inventory -- api.tests ui.tests ui.e2e
 ```
 
-The command accepts only observations from the current unchanged checkout. Review
-the resulting added/removed case identities against the test changes, then rerun
-verification. It does not declare its own update verified. If only one lane changed,
-name only that lane. If several changed, update them together; each update changes
-the source fingerprint. Never accept an unexpected shrink merely to make CI green.
+This first command is a preview: it prints exact added/removed identities and a
+review token without updating files. Approve the same diff explicitly:
+
+```sh
+bun run agent:inventory -- api.tests ui.tests ui.e2e --accept=<token>
+```
+
+If any cases are removed (including one occurrence of a duplicate or a same-count
+replacement), also supply `--allow-removals=<token>`. This acknowledges the exact
+removals already displayed; it is not a blanket permission for future reductions.
+The token binds the checkout, old baseline and fresh observation. Any change
+invalidates approval. Choose only changed lanes, approve them together, review the
+committed diff, then rerun verification. Approval never declares the update verified.
 
 Owned browser invocations disable retries. A retry attachment is blocked if fed
 back as evidence. Coverage/forbidden-warning gate failures are reported as failures
 when the complete test inventory agrees; missing or crashed execution stays blocked.
+
+The owned API uses Bun; the owned Vite server uses Node, matching Vite’s CLI runtime. Install Node compatible with the UI package’s engine requirements alongside Bun. Both servers bind to IPv4 loopback, and readiness checks report transport/HTTP failures separately from process exits.

--- a/tools/agent/environment.ts
+++ b/tools/agent/environment.ts
@@ -1,6 +1,10 @@
 /** Only host executable locations and the explicit verification switches are read. */
 export function hostEnvironment(): Record<string, string | undefined> {
-  return { PATH: process.env.PATH, HOME: process.env.HOME };
+  return {
+    PATH: process.env.PATH,
+    HOME: process.env.HOME,
+    PLAYWRIGHT_BROWSERS_PATH: process.env.PLAYWRIGHT_BROWSERS_PATH,
+  };
 }
 
 export function openApiUrl(): string {

--- a/tools/agent/generate/cli.ts
+++ b/tools/agent/generate/cli.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath } from "node:url";
 import { planAccountResource } from "./account-resource";
 import { formatEdits } from "./format";
+import { validateGeneratedTypes } from "./typecheck";
 import { apply } from "./patch";
 
 const root = fileURLToPath(new URL("../../../", import.meta.url));
@@ -31,6 +32,7 @@ try {
     planAccountResource(root, name, policy)
   );
 
+  validateGeneratedTypes(root, edits);
   apply(root, edits, args.includes("--dry-run"));
   console.log(
     JSON.stringify({

--- a/tools/agent/generate/fixture.ts
+++ b/tools/agent/generate/fixture.ts
@@ -3,7 +3,7 @@ import { constants, cpSync, existsSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 /** Copy reviewed source, never ignored env/credentials or existing runtime state. */
-export function copyFixture(root: string, destination: string): void {
+export function copySource(root: string, destination: string): void {
   mkdirSync(destination, { recursive: true });
   const files = execFileSync(
     "git",
@@ -39,6 +39,10 @@ export function copyFixture(root: string, destination: string): void {
     mkdirSync(dirname(join(destination, path)), { recursive: true });
     cpSync(source, join(destination, path), { dereference: false });
   }
+}
+
+export function copyFixture(root: string, destination: string): void {
+  copySource(root, destination);
 
   for (const app of ["api", "ui"]) {
     cpSync(

--- a/tools/agent/generate/typecheck.test.ts
+++ b/tools/agent/generate/typecheck.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { requireValue } from "../validation";
+import { validateGeneratedTypes } from "./typecheck";
+
+const GENERATED = "apps/api/src/generated/value.ts";
+
+test("semantic validation resolves new modules and rejects incompatible edits before writes", () => {
+  const root = mkdtempSync(join(tmpdir(), "bs-typecheck-"));
+
+  try {
+    mkdirSync(join(root, "apps/api/src"), { recursive: true });
+    writeFileSync(
+      join(root, "apps/api/tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: { strict: true, noEmit: true, skipLibCheck: true },
+        include: ["src/**/*.ts"],
+      })
+    );
+    writeFileSync(
+      join(root, "apps/api/src/index.ts"),
+      'export const value: string = "original";'
+    );
+    const changes = [
+      {
+        path: "apps/api/src/index.ts",
+        before: 'export const value: string = "original";',
+        after:
+          'import { value } from "./generated/value"; export const text: string = value;',
+      },
+      {
+        path: GENERATED,
+        before: null,
+        after: 'export const value = "generated";',
+      },
+    ];
+
+    expect(() => {
+      validateGeneratedTypes(root, changes);
+    }).not.toThrow();
+    expect(() => {
+      validateGeneratedTypes(root, [
+        requireValue(changes[0], "Missing test edit"),
+        { path: GENERATED, before: null, after: "export const value = 42;" },
+      ]);
+    }).toThrow("not assignable");
+    expect(existsSync(join(root, GENERATED))).toBe(false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tools/agent/generate/typecheck.ts
+++ b/tools/agent/generate/typecheck.ts
@@ -1,0 +1,87 @@
+import { dirname, join, resolve } from "node:path";
+import ts from "../../../apps/api/node_modules/typescript";
+import type { IEdit } from "./patch";
+
+/** Resolve the entire prospective API program in memory before any generated file is written. */
+export function validateGeneratedTypes(
+  root: string,
+  edits: readonly IEdit[]
+): void {
+  const apiRoot = join(root, "apps/api");
+  const configPath = join(apiRoot, "tsconfig.json");
+  const config = ts.readConfigFile(configPath, (path) => ts.sys.readFile(path));
+
+  if (config.error !== undefined) {
+    throw new Error(
+      ts.flattenDiagnosticMessageText(config.error.messageText, "\n")
+    );
+  }
+
+  const parsed = ts.parseJsonConfigFileContent(
+    config.config,
+    ts.sys,
+    apiRoot,
+    undefined,
+    configPath
+  );
+  const overlay = new Map(
+    edits.map((plannedEdit) => [
+      resolve(root, plannedEdit.path),
+      plannedEdit.after,
+    ])
+  );
+  const directories = new Set<string>();
+
+  for (const path of overlay.keys()) {
+    for (
+      let directory = dirname(path);
+      directory !== dirname(directory);
+      directory = dirname(directory)
+    ) {
+      directories.add(directory);
+    }
+  }
+
+  const host = ts.createCompilerHost(parsed.options);
+
+  host.getCurrentDirectory = () => apiRoot;
+  const readFile = host.readFile.bind(host);
+  const fileExists = host.fileExists.bind(host);
+  const directoryExists = host.directoryExists?.bind(host);
+
+  host.readFile = (path) => overlay.get(resolve(path)) ?? readFile(path);
+  host.fileExists = (path) => overlay.has(resolve(path)) || fileExists(path);
+  host.directoryExists = (path) =>
+    directories.has(resolve(path)) || directoryExists?.(path) === true;
+
+  host.getSourceFile = (path, languageVersion) => {
+    const source = host.readFile(path);
+
+    return source === undefined
+      ? undefined
+      : ts.createSourceFile(path, source, languageVersion, true);
+  };
+
+  const addedFiles = [...overlay.keys()].filter(
+    (path) => path.startsWith(`${apiRoot}/`) && /\.tsx?$/.test(path)
+  );
+  const program = ts.createProgram({
+    rootNames: [...new Set([...parsed.fileNames, ...addedFiles])],
+    options: { ...parsed.options, noEmit: true, incremental: false },
+    host,
+  });
+  const errors = [
+    ...parsed.errors,
+    ...ts.getPreEmitDiagnostics(program),
+  ].filter((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error);
+
+  if (errors.length > 0) {
+    throw new Error(
+      ts.formatDiagnostics(errors, {
+        getCanonicalFileName: (path) => path,
+        getCurrentDirectory: () => root,
+        getNewLine: () => "\n",
+      })
+    );
+  }
+}

--- a/tools/agent/hardening.test.ts
+++ b/tools/agent/hardening.test.ts
@@ -16,6 +16,7 @@ import { planAccountResource } from "./generate/account-resource";
 import { formatEdits } from "./generate/format";
 import {
   acceptInventories,
+  reviewInventories,
   compareInventory,
   identities,
   inventoryEvidence,
@@ -212,7 +213,11 @@ test("inventory observations cannot be accepted after source changes", () => {
     );
 
     expect(result.status).toBe("blocked");
-    acceptInventories(dir, ["api.tests"]);
+    acceptInventories(
+      dir,
+      ["api.tests"],
+      reviewInventories(dir, ["api.tests"]).token
+    );
     expect(
       inventoryEvidence(
         dir,
@@ -222,9 +227,36 @@ test("inventory observations cannot be accepted after source changes", () => {
         identifyCheckout(dir).fingerprint
       ).status
     ).toBe("passed");
+    const baseline = join(dir, "tools/agent/inventories/api.tests.json");
+    const originalBaseline = readFileSync(baseline, "utf8");
+    const substituted = xml.replace('name="control"', 'name="replacement"');
+
+    inventoryEvidence(
+      dir,
+      "api.tests",
+      substituted,
+      { checkId: "api.tests", status: "passed", reason: "tests_passed" },
+      identifyCheckout(dir).fingerprint
+    );
+    const review = reviewInventories(dir, ["api.tests"]);
+
+    expect(review.changes[0]?.removed).toEqual(['["a.ts","control"]']);
+    expect(() => {
+      acceptInventories(dir, ["api.tests"], review.token);
+    }).toThrow("removals");
+    expect(readFileSync(baseline, "utf8")).toBe(originalBaseline);
+    expect(() => {
+      acceptInventories(dir, ["api.tests"], "stale", review.token);
+    }).toThrow("changed");
+    acceptInventories(dir, ["api.tests"], review.token, review.token);
+    expect(readFileSync(baseline, "utf8")).toContain("replacement");
     writeFileSync(join(dir, "changed.ts"), "export const changed=true;");
     expect(() => {
-      acceptInventories(dir, ["api.tests"]);
+      acceptInventories(
+        dir,
+        ["api.tests"],
+        reviewInventories(dir, ["api.tests"]).token
+      );
     }).toThrow("stale");
     expect(
       existsSync(join(dir, "tools/agent/inventories/api.tests.json"))

--- a/tools/agent/inventory-cli.ts
+++ b/tools/agent/inventory-cli.ts
@@ -1,27 +1,62 @@
 import { fileURLToPath } from "node:url";
-import { acceptInventories, isInventoryLane } from "./inventory";
+import {
+  acceptInventories,
+  isInventoryLane,
+  reviewInventories,
+} from "./inventory";
 import { acquireWorkspace } from "./workspace-lock";
 
 const args = process.argv.slice(2).filter((first) => first !== "--");
+const lanes = args.filter((arg) => !arg.startsWith("--"));
+const accept = args.find((arg) => arg.startsWith("--accept="))?.slice(9);
+const removals = args
+  .find((arg) => arg.startsWith("--allow-removals="))
+  ?.slice(17);
 let release: (() => void) | undefined;
 
 try {
   release = acquireWorkspace(fileURLToPath(new URL("../../", import.meta.url)));
 
   if (
-    args.length === 0 ||
-    new Set(args).size !== args.length ||
-    !args.every(isInventoryLane)
+    lanes.length === 0 ||
+    new Set(args.map((arg) => arg.split("=")[0])).size !== args.length ||
+    !lanes.every(isInventoryLane) ||
+    args.some(
+      (arg) =>
+        arg.startsWith("--") &&
+        !/^--(?:accept|allow-removals)=[a-f0-9]{64}$/.test(arg)
+    )
   ) {
     throw new Error(
       "Use agent:inventory -- <api.tests|ui.tests|ui.e2e>; review the resulting case diff"
     );
   }
 
-  acceptInventories(fileURLToPath(new URL("../../", import.meta.url)), args);
+  const root = fileURLToPath(new URL("../../", import.meta.url));
+  const review = reviewInventories(root, lanes);
+
   console.log(
-    "Inventory updated. Review the added and removed case identities before accepting it."
+    JSON.stringify(
+      {
+        fingerprint: review.fingerprint,
+        token: review.token,
+        changes: review.changes.map((change) => ({
+          lane: change.lane,
+          beforeCount: change.before.length,
+          afterCount: change.after.length,
+          added: change.added,
+          removed: change.removed,
+        })),
+      },
+      null,
+      2
+    )
   );
+
+  if (accept !== undefined) {
+    acceptInventories(root, lanes, accept, removals);
+    console.log("Approved inventory applied.");
+  }
 } catch (error) {
   console.error(
     error instanceof Error ? error.message : "Inventory update failed"

--- a/tools/agent/inventory-review.test.ts
+++ b/tools/agent/inventory-review.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+import { inventoryChange, inventoryReview } from "./inventory-review";
+
+test("inventory approval binds duplicates, substitutions, additions and the checkout", () => {
+  const change = inventoryChange(
+    "api.tests",
+    ["control", "invariant", "invariant"],
+    ["control", "replacement", "invariant"]
+  );
+
+  expect(change.added).toEqual(["replacement"]);
+  expect(change.removed).toEqual(["invariant"]);
+  const reviewed = inventoryReview("checkout", [change]);
+
+  expect(inventoryReview("different-checkout", [change]).token).not.toBe(
+    reviewed.token
+  );
+  expect(
+    inventoryReview("checkout", [
+      inventoryChange("api.tests", change.before, ["control", "invariant"]),
+    ]).token
+  ).not.toBe(reviewed.token);
+  expect(
+    inventoryReview("checkout", [
+      inventoryChange(
+        "api.tests",
+        [...change.before].reverse(),
+        [...change.after].reverse()
+      ),
+    ]).token
+  ).toBe(reviewed.token);
+});

--- a/tools/agent/inventory-review.ts
+++ b/tools/agent/inventory-review.ts
@@ -1,0 +1,66 @@
+import { createHash } from "node:crypto";
+import type { InventoryLane } from "./inventory.types";
+
+export interface IInventoryChange {
+  lane: InventoryLane;
+  before: string[];
+  after: string[];
+  added: string[];
+  removed: string[];
+}
+
+export interface IInventoryReview {
+  fingerprint: string;
+  changes: IInventoryChange[];
+  token: string;
+}
+
+/** Multiset subtraction preserves repeated cases rather than collapsing them. */
+function difference(
+  left: readonly string[],
+  right: readonly string[]
+): string[] {
+  const remaining = [...right];
+
+  return left
+    .filter((identity) => {
+      const index = remaining.indexOf(identity);
+
+      if (index < 0) {
+        return true;
+      }
+
+      remaining.splice(index, 1);
+
+      return false;
+    })
+    .sort();
+}
+
+export function inventoryChange(
+  lane: InventoryLane,
+  before: string[],
+  after: string[]
+): IInventoryChange {
+  return {
+    lane,
+    before: [...before].sort(),
+    after: [...after].sort(),
+    added: difference(after, before),
+    removed: difference(before, after),
+  };
+}
+
+export function inventoryReview(
+  fingerprint: string,
+  changes: IInventoryChange[]
+): IInventoryReview {
+  const ordered = [...changes].sort((left, right) =>
+    left.lane.localeCompare(right.lane)
+  );
+  const token = createHash("sha256")
+    .update(JSON.stringify({ fingerprint, changes: ordered }))
+    .digest("hex");
+
+  return { fingerprint, changes: ordered, token };
+}

--- a/tools/agent/inventory.ts
+++ b/tools/agent/inventory.ts
@@ -1,7 +1,18 @@
-import { lstatSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 
 import { identifyCheckout } from "./checkout";
+import {
+  inventoryChange,
+  inventoryReview,
+  type IInventoryReview,
+} from "./inventory-review";
 import type { IInventory, InventoryLane } from "./inventory.types";
 import type { ICheckResult } from "./result";
 import { isRecord, isStringArray, parseRecord } from "./validation";
@@ -157,16 +168,53 @@ function readFreshObservation(
   return readInventory(path);
 }
 
-/** Validate the entire batch before writes; verification never enrolls its own expectations. */
-export function acceptInventories(
+/** Preview exact additions and removals without changing the committed baseline. */
+export function reviewInventories(
   root: string,
   lanes: readonly InventoryLane[]
-): void {
+): IInventoryReview {
   const checkout = identifyCheckout(root);
-  const observations = lanes.map((lane) => ({
-    lane,
-    inventory: readFreshObservation(root, lane, checkout.fingerprint),
-  }));
+
+  assertSafePath(join(root, "tools/agent/inventories"));
+
+  const changes = lanes.map((lane) => {
+    const observation = readFreshObservation(root, lane, checkout.fingerprint);
+    const path = join(root, "tools/agent/inventories", `${lane}.json`);
+
+    if (existsSync(path)) {
+      assertSafePath(path);
+    }
+
+    const before = existsSync(path) ? readInventory(path).cases : [];
+
+    return inventoryChange(lane, before, observation.cases);
+  });
+
+  return inventoryReview(checkout.fingerprint, changes);
+}
+
+/** Approvals bind the exact checkout and case diff; removals require a second explicit acknowledgement. */
+export function acceptInventories(
+  root: string,
+  lanes: readonly InventoryLane[],
+  token: string,
+  removalToken?: string
+): void {
+  const review = reviewInventories(root, lanes);
+
+  if (token !== review.token) {
+    throw new Error(
+      "Inventory review changed; preview and approve the current diff"
+    );
+  }
+
+  if (
+    review.changes.some((change) => change.removed.length > 0) &&
+    removalToken !== review.token
+  ) {
+    throw new Error("Test removals require --allow-removals=<review token>");
+  }
+
   const directory = join(root, "tools/agent/inventories");
 
   assertSafePath(directory);
@@ -177,10 +225,10 @@ export function acceptInventories(
 
   mkdirSync(directory, { recursive: true });
 
-  for (const { lane, inventory } of observations) {
+  for (const change of review.changes) {
     writeFileSync(
-      join(directory, `${lane}.json`),
-      `${JSON.stringify(inventory, null, 2)}\n`
+      join(directory, `${change.lane}.json`),
+      `${JSON.stringify({ schemaVersion: 1, cases: change.after }, null, 2)}\n`
     );
   }
 }

--- a/tools/agent/isolated.test.ts
+++ b/tools/agent/isolated.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,7 +8,7 @@ import { docker } from "../agent-evals/isolated/docker";
 import { candidateOutcome } from "../agent-evals/isolated/outcome";
 import { runnerArguments } from "../agent-evals/isolated/policy";
 import { withIsolatedRuntime } from "../agent-evals/isolated/runtime";
-import { dockerTestsEnabled } from "./environment";
+import { dockerTestsEnabled, hostEnvironment } from "./environment";
 import { runProcess } from "./process";
 
 const ROOT = fileURLToPath(new URL("../../", import.meta.url));
@@ -63,6 +63,47 @@ test("candidate completion rejects missing, duplicated and contradictory evidenc
       0
     )
   ).toBe(2);
+});
+
+test("Docker failures expose status without echoing credential arguments or stderr", async () => {
+  const directory = mkdtempSync(join(tmpdir(), "bs-docker-error-"));
+  const credential = "disposable-test-credential";
+
+  try {
+    const executable = join(directory, "docker");
+
+    writeFileSync(
+      executable,
+      `#!/bin/sh
+if [ "$1" = "success" ]; then printf ready; exit 0; fi
+printf '%s\\n' '${credential}' >&2
+exit 7
+`
+    );
+    chmodSync(executable, 0o700);
+    const result = await runProcess(
+      [
+        process.execPath,
+        "--no-env-file",
+        "-e",
+        `import {docker} from ${JSON.stringify(join(ROOT, "tools/agent-evals/isolated/docker.ts"))};
+        console.log(await docker(${JSON.stringify(ROOT)}, ["success"]));
+        try { await docker(${JSON.stringify(ROOT)}, ["run", ${JSON.stringify(credential)}]); }
+        catch (error) { console.error(error.message); process.exitCode = 2; }`,
+      ],
+      {
+        cwd: ROOT,
+        env: { PATH: `${directory}:${hostEnvironment().PATH ?? ""}` },
+      }
+    );
+
+    expect(result.code).toBe(2);
+    expect(result.stdout.trim()).toBe("ready");
+    expect(result.stderr).not.toContain(credential);
+    expect(result.stderr).toContain("command_completed; exit=7");
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 if (dockerTestsEnabled()) {

--- a/tools/agent/isolated.test.ts
+++ b/tools/agent/isolated.test.ts
@@ -1,0 +1,160 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { sendInput } from "../agent-evals/isolated/input";
+import { docker } from "../agent-evals/isolated/docker";
+import { candidateOutcome } from "../agent-evals/isolated/outcome";
+import { runnerArguments } from "../agent-evals/isolated/policy";
+import { withIsolatedRuntime } from "../agent-evals/isolated/runtime";
+import { dockerTestsEnabled } from "./environment";
+import { runProcess } from "./process";
+
+const ROOT = fileURLToPath(new URL("../../", import.meta.url));
+
+test("candidate launch policy includes kernel isolation and excludes host authority", () => {
+  const args = runnerArguments("candidate", "image");
+
+  for (const required of [
+    "--read-only",
+    "--cap-drop",
+    "--security-opt",
+    "--pids-limit",
+    "--memory",
+    "--cpus",
+  ]) {
+    expect(args).toContain(required);
+  }
+
+  expect(args[args.indexOf("--network") + 1]).toBe("none");
+  expect(args).not.toContain("--privileged");
+  expect(args).not.toContain("--volume");
+  expect(args).not.toContain("--mount");
+});
+
+test("candidate completion rejects missing, duplicated and contradictory evidence", () => {
+  const checks = [
+    "submission",
+    "ui-known-good",
+    "api.check",
+    "ui.check",
+    "projects.browser",
+  ].map((checkId) => ({ checkId, status: "passed" }));
+  const evidence = {
+    schemaVersion: 1,
+    kind: "candidate-review",
+    status: "passed",
+    checks,
+  };
+
+  expect(candidateOutcome("", 0)).toBe(2);
+  expect(candidateOutcome(JSON.stringify(evidence), 0)).toBe(0);
+  expect(candidateOutcome(JSON.stringify(evidence), 1)).toBe(2);
+  expect(
+    candidateOutcome(
+      JSON.stringify({ ...evidence, checks: checks.slice(1) }),
+      0
+    )
+  ).toBe(2);
+  expect(
+    candidateOutcome(
+      JSON.stringify({ ...evidence, checks: [...checks, checks[0]] }),
+      0
+    )
+  ).toBe(2);
+});
+
+if (dockerTestsEnabled()) {
+  test("candidate isolation denies host access and still runs the complete positive control", async () => {
+    let resourceName = "";
+    const input = mkdtempSync(join(tmpdir(), "bs-isolation-test-"));
+
+    try {
+      const status = await withIsolatedRuntime(
+        ROOT,
+        async ({ name, state }) => {
+          resourceName = name;
+          const probe = await docker(ROOT, [
+            "exec",
+            name,
+            "bun",
+            "-e",
+            `
+          import {readFileSync,existsSync,writeFileSync} from "node:fs";
+          import {strict as assert} from "node:assert";
+          assert.equal(process.getuid(),1000);
+          assert.equal(existsSync("/var/run/docker.sock"),false);
+          assert.equal(existsSync(${JSON.stringify(ROOT)}),false);
+          assert.match(readFileSync("/proc/self/status","utf8"),/CapEff:\\s+0+\\n/);
+          assert.match(readFileSync("/proc/self/status","utf8"),/NoNewPrivs:\\s+1/);
+          assert.equal(readFileSync("/proc/net/route","utf8").trim().split("\\n").length,1);
+          assert.throws(()=>writeFileSync("/review/package.json","tampered"));
+          writeFileSync("/tmp/allowed","ok");
+          console.log("isolated");
+        `,
+          ]);
+
+          expect(probe).toBe("isolated");
+          writeFileSync(join(input, "sandbox.json"), JSON.stringify(state), {
+            mode: 0o644,
+          });
+          sendInput(name, input);
+          await docker(
+            ROOT,
+            [
+              "exec",
+              name,
+              "bun",
+              "--no-env-file",
+              "-e",
+              'import {prepareControl} from "/review/tools/agent-evals/isolated/control.fixture.ts"; await prepareControl();',
+            ],
+            300_000
+          );
+          const result = await runProcess(
+            [
+              "docker",
+              "exec",
+              name,
+              "bun",
+              "--no-env-file",
+              "/review/tools/agent-evals/isolated/worker.ts",
+            ],
+            { cwd: ROOT, timeoutMs: 900_000 }
+          );
+
+          expect(result.status).toBe("completed");
+
+          if (result.code !== 0) {
+            throw new Error(
+              `Isolated control did not pass\n${result.stderr}\n${result.stdout.slice(-8000)}`
+            );
+          }
+
+          expect(result.code).toBe(0);
+          expect(candidateOutcome(result.stdout, result.code)).toBe(0);
+          expect(result.stdout).toContain(
+            '"kind":"candidate-review","status":"passed"'
+          );
+
+          return result.code;
+        }
+      );
+
+      expect(status).toBe(0);
+      expect(
+        await docker(ROOT, [
+          "ps",
+          "-a",
+          "--filter",
+          `name=${resourceName}`,
+          "--format",
+          "{{.Names}}",
+        ]).then((value) => value.trim())
+      ).toBe("");
+    } finally {
+      rmSync(input, { recursive: true, force: true });
+    }
+  }, 1_800_000);
+}

--- a/tools/agent/runtime.test.ts
+++ b/tools/agent/runtime.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { startRuntime } from "./runtime";
+import type { ISandbox } from "./sandbox/lifecycle";
+
+test("owned runtime launches the UI under Node and verifies the IPv4 proxy", async () => {
+  const root = mkdtempSync(join(tmpdir(), "bs-runtime-test-"));
+  const files = {
+    "apps/api/src/config/app/app.ts": `export function createApp() {
+      return { server: undefined, use() { return this; }, listen(options) {
+        this.server = Bun.serve({...options, fetch: () => Response.json({ready:true})});
+        return this;
+      }};
+    }`,
+    "apps/api/src/config/setup/index.ts":
+      "export function setupNotifications() {}",
+    "apps/api/src/config/swagger/swagger.ts":
+      "export const swaggerConfig = {};",
+    "apps/ui/package.json": '{"type":"module"}',
+    "apps/ui/node_modules/vite/bin/vite.js": `import {createServer} from "node:http";
+      if (process.versions.bun !== undefined) throw new Error("Vite requires the Node runtime");
+      const port=Number(process.argv[process.argv.indexOf("--port")+1]);
+      createServer(async (_request,response) => {
+        const upstream=await fetch(process.env.VITE_API_PROXY_TARGET+"/api/v1/capabilities");
+        response.writeHead(upstream.status,{"content-type":"application/json"});
+        response.end(await upstream.text());
+      }).listen(port,"127.0.0.1");`,
+  };
+  const state: ISandbox = {
+    version: 1,
+    id: "fixture",
+    owner: "fixture",
+    root,
+    createdAt: "fixture",
+    password: "fixture",
+    valkeyPassword: "fixture",
+    postgres: "unused",
+    valkey: "unused",
+    postgresPort: 1,
+    valkeyPort: 1,
+  };
+
+  try {
+    for (const [path, source] of Object.entries(files)) {
+      mkdirSync(dirname(join(root, path)), { recursive: true });
+      writeFileSync(join(root, path), source);
+    }
+
+    const runtime = await startRuntime(root, state, AbortSignal.timeout(5000));
+
+    try {
+      expect(runtime.uiUrl).toStartWith("http://localhost:");
+      const response = await fetch(`${runtime.uiUrl}/api/v1/capabilities`);
+
+      expect(response.status).toBe(200);
+    } finally {
+      await runtime.stop();
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}, 10_000);

--- a/tools/agent/runtime.ts
+++ b/tools/agent/runtime.ts
@@ -73,14 +73,19 @@ export async function startRuntime(
   const launch = (
     args: string[],
     cwd: string,
-    env: Record<string, string>
+    env: Record<string, string>,
+    runtime: "bun" | "node" = "bun"
   ): ChildProcess => {
-    const child = spawn(process.execPath, ["--no-env-file", ...args], {
-      cwd,
-      env,
-      detached: true,
-      stdio: "ignore",
-    });
+    const child = spawn(
+      runtime === "bun" ? process.execPath : "node",
+      runtime === "bun" ? ["--no-env-file", ...args] : args,
+      {
+        cwd,
+        env,
+        detached: true,
+        stdio: "ignore",
+      }
+    );
 
     child.on("error", () => {
       failedChildren.add(child);
@@ -186,8 +191,11 @@ await Bun.write(
         "--strictPort",
       ],
       join(root, "apps/ui"),
-      fullEnv
+      fullEnv,
+      "node"
     );
+
+    let readiness = "not probed";
 
     for (let i = 0; ; i++) {
       if (
@@ -196,19 +204,26 @@ await Bun.write(
         failedChildren.has(ui) ||
         isAborted(signal)
       ) {
-        throw new Error("UI startup failed");
+        throw new Error(
+          `UI startup failed (${readiness}; exit=${String(ui.exitCode)})`
+        );
       }
 
       try {
-        const response = await fetch(`${uiUrl}/api/v1/capabilities`, {
-          signal: AbortSignal.timeout(1000),
-        });
+        const response = await fetch(
+          `http://127.0.0.1:${uiPort}/api/v1/capabilities`,
+          {
+            signal: AbortSignal.timeout(1000),
+          }
+        );
+
+        readiness = `HTTP ${String(response.status)}`;
 
         if (response.ok) {
           break;
         }
-      } catch {
-        /* Startup still in progress. */
+      } catch (error) {
+        readiness = error instanceof Error ? error.name : "connection failed";
       }
 
       await Bun.sleep(250);
@@ -241,8 +256,7 @@ export async function fullStackChecks(
     );
     const run = await runProcess(
       [
-        process.execPath,
-        "--no-env-file",
+        "node",
         "node_modules/@playwright/test/cli.js",
         "test",
         "--project=chromium",

--- a/tools/agent/sandbox/lifecycle.ts
+++ b/tools/agent/sandbox/lifecycle.ts
@@ -364,6 +364,12 @@ export function sandboxEnv(state: ISandbox): Record<string, string> {
 
   return {
     AGENT_SANDBOX: "1",
+    ...(hostEnvironment().PLAYWRIGHT_BROWSERS_PATH === undefined
+      ? {}
+      : {
+          PLAYWRIGHT_BROWSERS_PATH:
+            hostEnvironment().PLAYWRIGHT_BROWSERS_PATH ?? "",
+        }),
     PATH: hostEnvironment().PATH ?? "",
     HOME: hostEnvironment().HOME ?? "",
     NODE_ENV: "test",

--- a/tools/agent/stack-check.test.ts
+++ b/tools/agent/stack-check.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test";
+import { execFileSync, spawnSync } from "node:child_process";
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+test("root check distinguishes an unavailable OpenAPI gate from success and real failure", () => {
+  const root = mkdtempSync(join(tmpdir(), "bs-stack-check-"));
+
+  try {
+    mkdirSync(join(root, "scripts"));
+    mkdirSync(join(root, "bin"));
+    mkdirSync(join(root, "apps/api"), { recursive: true });
+    mkdirSync(join(root, "apps/ui"), { recursive: true });
+
+    for (const name of ["stack-check.sh", "stack-lib.sh"]) {
+      cpSync(
+        join(import.meta.dir, "../../scripts", name),
+        join(root, "scripts", name)
+      );
+    }
+
+    for (const [available, commandExit, expected] of [
+      [false, 0, 2],
+      [true, 0, 0],
+      [false, 1, 1],
+    ] as const) {
+      writeFileSync(
+        join(root, "bin/curl"),
+        `#!/bin/bash\nexit ${available ? "0" : "1"}\n`,
+        { mode: 0o755 }
+      );
+      writeFileSync(
+        join(root, "bin/bun"),
+        `#!/bin/bash\nexit ${String(commandExit)}\n`,
+        { mode: 0o755 }
+      );
+      const result = spawnSync(
+        "/bin/bash",
+        [join(root, "scripts/stack-check.sh")],
+        {
+          env: { PATH: `${join(root, "bin")}:/usr/bin:/bin` },
+          encoding: "utf8",
+        }
+      );
+
+      expect(result.status).toBe(expected);
+    }
+
+    expect(
+      execFileSync("/bin/bash", ["-n", join(root, "scripts/stack-check.sh")])
+        .length
+    ).toBe(0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tools/agent/tasks/account-resource.json
+++ b/tools/agent/tasks/account-resource.json
@@ -64,7 +64,7 @@
     "Use the existing UI component/feature conventions. Scope every query key by accountId; capture accountId in mutations and invalidate that exact account's queries.",
     "Render loading, empty, error and permission-denied states. Translate visible labels into both locales. Do not put service authorization exclusively in the UI.",
     "Verify owner/admin mutations, member/viewer read access, revoked membership, cross-account reads and writes, forged ownership, and account-switch cache isolation.",
-    "Run feature verification. If intentional test additions change the inventory, explicitly run agent:inventory for the affected lanes, review its case diff, and rerun verification. Run release-local before claiming full local readiness. Report blockers and GitHub-only checks separately."
+    "Run feature verification. If intentional test additions change the inventory, preview agent:inventory for the affected lanes, review its case diff, apply --accept=<token> (plus --allow-removals=<token> for intentional removals), and rerun verification. Run release-local before claiming full local readiness. Report blockers and GitHub-only checks separately."
   ],
   "verificationProfile": "feature",
   "limitations": [


### PR DESCRIPTION
## Summary

The agent verification job could leave Vite alive but unreachable when its Node CLI was forced through Bun. Run Vite and Playwright under Node, probe readiness over IPv4, and keep the browser origin on localhost for secure cookies. A regression test requires the UI process to run under Node; the real startup path passed ten consecutive runs.

This also completes the four verification follow-ups from #443:

- Root `check` exits 2 when required OpenAPI verification is unavailable instead of reporting success.
- Inventory updates first display an exact case diff. Applying it requires a checkout-bound review token; removals and substitutions require explicit approval of that same diff.
- Candidate application code runs in a non-root container with no host mounts, Docker socket or external network, a read-only root, resource limits, and disposable loopback Postgres/Valkey. A full positive control proves API, UI and browser acceptance work within that boundary.
- The account-resource CLI semantically typechecks the prospective API program in memory before writing, including during dry runs.

Astro guides and the published task recipe document the changed commands and guarantees. Candidate isolation protects the host; it does not make same-process assertions immune to malicious application code. The threat model records that limit.

## Test plan

- [x] Root `bun run check` with a disposable live API, including OpenAPI verification
- [x] Isolated candidate positive control, effective privilege/network/filesystem probes, and cleanup
- [x] Disposable sandbox lifecycle and independent-state tests
- [x] Real account-resource CLI dry run with semantic typechecking
- [x] Astro `build:ci` and published recipe drift checks

- [x] Latest-head CI tooling suite: 48 passed, 0 failed; the credential-log regression also fails against the previous implementation
- [x] Latest-head CI Docker suite: 6 passed, 0 failed, including the full isolated positive control
- [x] Latest-head CI deterministic evaluation: all 15 checks passed
- [x] Strict typecheck, lint and formatting after the log-safety follow-up
- [x] Normal repository pre-push gates

CodeQL identified a Docker error path that could echo credential arguments or stderr. The follow-up commit limits that message to process status and exit code, with a subprocess regression that verifies both failure confidentiality and successful output. All 23 GitHub checks pass at head `11a3829`; the PR is clean and mergeable. [Final agent-verification run](https://github.com/boringstack-xyz/boringstack/actions/runs/34572397888).

## Conventions

- [x] Strict tooling typecheck, lint and formatting apply to the new code
- [x] Regression tests cover changed behavior
- [x] No application environment settings or production API behavior changed
